### PR TITLE
feat: add livestream and premiere filtering via SKIP_LIVE_CONTENT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ VIDEO_MIN_DURATION_SECONDS=120
 LOOKBACK_HOURS=24
 MAX_VIDEOS_TO_FETCH=50
 
+# Skip livestreams and premieres (true/false)
+SKIP_LIVE_CONTENT=true
+
 # Channel filtering (optional)
 # Comma-separated list of channel IDs to include (leave empty to include all)
 # To find channel ID: go to channel -> About tab -> copy channel ID

--- a/main.py
+++ b/main.py
@@ -7,18 +7,19 @@ based on duration and other criteria, and adds them to a specified playlist.
 Perfect for running as a cron job to keep your playlists updated.
 """
 
-import os
-import sys
 import argparse
 import logging
-from typing import List, Dict, Any, Optional, Set
+import os
+import sys
+from typing import Any, Dict, List, Optional, Set
+
 from dotenv import load_dotenv
 
 from utils import (
-    setup_logging, 
-    get_published_after_timestamp, 
+    VideoCache,
+    get_published_after_timestamp,
     parse_channel_whitelist,
-    VideoCache
+    setup_logging,
 )
 from youtube_api import YouTubeAPI
 
@@ -28,77 +29,92 @@ logger = logging.getLogger(__name__)
 def load_config() -> Dict[str, Any]:
     """Load configuration from environment variables with defaults."""
     load_dotenv()
-    
+
     config = {
-        'playlist_id': os.getenv('PLAYLIST_ID'),
-        'playlist_name': os.getenv('PLAYLIST_NAME', 'Auto Playlist from Subscriptions'),
-        'playlist_visibility': os.getenv('PLAYLIST_VISIBILITY', 'unlisted'),
-        'min_duration_seconds': int(os.getenv('VIDEO_MIN_DURATION_SECONDS', '60')),
-        'lookback_hours': int(os.getenv('LOOKBACK_HOURS', '24')),
-        'channel_whitelist': parse_channel_whitelist(os.getenv('CHANNEL_ID_WHITELIST')),
-        'max_videos': int(os.getenv('MAX_VIDEOS_TO_FETCH', '50'))
+        "playlist_id": os.getenv("PLAYLIST_ID"),
+        "playlist_name": os.getenv("PLAYLIST_NAME", "Auto Playlist from Subscriptions"),
+        "playlist_visibility": os.getenv("PLAYLIST_VISIBILITY", "unlisted"),
+        "min_duration_seconds": int(os.getenv("VIDEO_MIN_DURATION_SECONDS", "60")),
+        "lookback_hours": int(os.getenv("LOOKBACK_HOURS", "24")),
+        "channel_whitelist": parse_channel_whitelist(os.getenv("CHANNEL_ID_WHITELIST")),
+        "max_videos": int(os.getenv("MAX_VIDEOS_TO_FETCH", "50")),
+        "skip_live_content": os.getenv("SKIP_LIVE_CONTENT", "true").lower() in ("true", "1", "yes"),
     }
-    
+
     return config
 
 
-def filter_videos(videos: List[Dict[str, Any]], 
-                 config: Dict[str, Any],
-                 cache: VideoCache,
-                 channel_whitelist: Optional[Set[str]] = None) -> List[Dict[str, Any]]:
+def filter_videos(
+    videos: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    cache: VideoCache,
+    channel_whitelist: Optional[Set[str]] = None,
+) -> List[Dict[str, Any]]:
     """
     Filter videos based on duration, whitelist, and cache status.
-    
+
     Args:
         videos: List of video data from YouTube API
         config: Configuration dictionary
         cache: VideoCache instance for checking processed videos
         channel_whitelist: Set of allowed channel IDs (None = allow all)
-        
+
     Returns:
         Filtered list of videos that should be added to playlist
     """
     filtered = []
     stats = {
-        'total': len(videos),
-        'too_short': 0,
-        'not_whitelisted': 0,
-        'already_processed': 0,
-        'passed_filters': 0
+        "total": len(videos),
+        "too_short": 0,
+        "not_whitelisted": 0,
+        "already_processed": 0,
+        "live_content_skipped": 0,
+        "passed_filters": 0,
     }
-    
-    min_duration = config['min_duration_seconds']
-    
+
+    min_duration = config["min_duration_seconds"]
+
     for video in videos:
-        video_id = video['video_id']
-        title = video['title']
-        channel_title = video['channel_title']
-        duration = video['duration_seconds']
-        
+        video_id = video["video_id"]
+        title = video["title"]
+        channel_title = video["channel_title"]
+        duration = video["duration_seconds"]
+
         # Check if already processed
         if cache.is_processed(video_id):
             logger.debug(f"Skipping already processed: {title}")
-            stats['already_processed'] += 1
+            stats["already_processed"] += 1
             continue
-        
+
         # Check duration filter
         if duration < min_duration:
             logger.debug(f"Skipping too short ({duration}s): {title}")
-            stats['too_short'] += 1
+            stats["too_short"] += 1
             continue
-        
+
         # Check channel whitelist
         if channel_whitelist is not None:
-            if video['channel_id'] not in channel_whitelist:
-                logger.debug(f"Skipping non-whitelisted channel {channel_title}: {title}")
-                stats['not_whitelisted'] += 1
+            if video["channel_id"] not in channel_whitelist:
+                logger.debug(
+                    f"Skipping non-whitelisted channel {channel_title}: {title}"
+                )
+                stats["not_whitelisted"] += 1
                 continue
-        
+
+        # Check live content filter
+        if config["skip_live_content"]:
+            live_broadcast = video.get("live_broadcast", "none")
+            if live_broadcast != "none":
+                live_type = "livestream" if live_broadcast == "live" else "premiere"
+                logger.info(f"Skipping {live_type}: {title}")
+                stats["live_content_skipped"] += 1
+                continue
+
         # Video passed all filters
-        stats['passed_filters'] += 1
+        stats["passed_filters"] += 1
         filtered.append(video)
         logger.info(f"✓ {title} ({duration}s) by {channel_title}")
-    
+
     # Log filtering statistics
     logger.info(f"Video filtering stats:")
     logger.info(f"  Total videos: {stats['total']}")
@@ -106,63 +122,67 @@ def filter_videos(videos: List[Dict[str, Any]],
     logger.info(f"  Too short (<{min_duration}s): {stats['too_short']}")
     if channel_whitelist:
         logger.info(f"  Not in whitelist: {stats['not_whitelisted']}")
+    if config["skip_live_content"]:
+        logger.info(f"  Live content skipped: {stats['live_content_skipped']}")
     logger.info(f"  Passed filters: {stats['passed_filters']}")
-    
+
     return filtered
 
 
-def add_videos_to_playlist(api: YouTubeAPI, 
-                          playlist_id: str, 
-                          videos: List[Dict[str, Any]],
-                          cache: VideoCache,
-                          dry_run: bool = False) -> Dict[str, bool]:
+def add_videos_to_playlist(
+    api: YouTubeAPI,
+    playlist_id: str,
+    videos: List[Dict[str, Any]],
+    cache: VideoCache,
+    dry_run: bool = False,
+) -> Dict[str, bool]:
     """
     Add filtered videos to the playlist and update cache.
-    
+
     Args:
         api: YouTube API wrapper instance
         playlist_id: Target playlist ID
         videos: List of videos to add
         cache: VideoCache instance for tracking processed videos
         dry_run: If True, don't actually add videos
-        
+
     Returns:
         Dict mapping video_id to success status
     """
     if not videos:
         logger.info("No videos to add to playlist")
         return {}
-    
+
     if dry_run:
-        logger.info(f"DRY RUN: Would add {len(videos)} videos to playlist {playlist_id}")
+        logger.info(
+            f"DRY RUN: Would add {len(videos)} videos to playlist {playlist_id}"
+        )
         for video in videos:
             logger.info(f"  - {video['title']} ({video['video_id']})")
-        return {video['video_id']: True for video in videos}
-    
+        return {video["video_id"]: True for video in videos}
+
     # Add videos to playlist
-    video_ids = [video['video_id'] for video in videos]
+    video_ids = [video["video_id"] for video in videos]
     results = api.add_videos_to_playlist(playlist_id, video_ids)
-    
+
     # Update cache for successful additions
     for video in videos:
-        video_id = video['video_id']
+        video_id = video["video_id"]
         if results.get(video_id, False):
             cache.mark_processed(
-                video_id, 
-                title=video['title'], 
-                channel=video['channel_title']
+                video_id, title=video["title"], channel=video["channel_title"]
             )
             logger.info(f"✅ Added: {video['title']}")
         else:
             logger.warning(f"❌ Failed to add: {video['title']}")
-    
+
     return results
 
 
 def main():
     """Main orchestration function."""
     parser = argparse.ArgumentParser(
-        description='Add new subscription videos to a YouTube playlist',
+        description="Add new subscription videos to a YouTube playlist",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -170,116 +190,121 @@ Examples:
   python main.py --dry-run          # See what would be added without changes
   python main.py --verbose          # Enable debug logging
   python main.py --limit 10         # Fetch max 10 recent videos
-        """
+        """,
     )
-    
+
     parser.add_argument(
-        '--dry-run', 
-        action='store_true',
-        help='Show what would be added without making changes'
+        "--dry-run",
+        action="store_true",
+        help="Show what would be added without making changes",
     )
-    
+
     parser.add_argument(
-        '--verbose', 
-        action='store_true',
-        help='Enable verbose debug logging'
+        "--verbose", action="store_true", help="Enable verbose debug logging"
     )
-    
+
     parser.add_argument(
-        '--limit', 
+        "--limit",
         type=int,
-        help='Maximum number of recent videos to fetch (overrides MAX_VIDEOS_TO_FETCH)'
+        help="Maximum number of recent videos to fetch (overrides MAX_VIDEOS_TO_FETCH)",
     )
-    
+
     args = parser.parse_args()
-    
+
     # Setup logging
     setup_logging(verbose=args.verbose)
-    
+
     try:
         # Load configuration
         config = load_config()
         if args.limit:
-            config['max_videos'] = args.limit
-        
-        logger.info(f"Starting playlist-from-subs ({'DRY RUN' if args.dry_run else 'LIVE RUN'})")
-        logger.info(f"Config: {config['lookback_hours']}h lookback, {config['min_duration_seconds']}s min duration")
-        
+            config["max_videos"] = args.limit
+
+        logger.info(
+            f"Starting playlist-from-subs ({'DRY RUN' if args.dry_run else 'LIVE RUN'})"
+        )
+        logger.info(
+            f"Config: {config['lookback_hours']}h lookback, {config['min_duration_seconds']}s min duration"
+        )
+
         # Initialize components
         api = YouTubeAPI()
         cache = VideoCache()
-        
+
         # Log cache stats
         cache_stats = cache.get_stats()
-        logger.info(f"Cache: {cache_stats['total_processed']} videos processed, "
-                   f"oldest entry {cache_stats['oldest_entry_days']} days")
-        
+        logger.info(
+            f"Cache: {cache_stats['total_processed']} videos processed, "
+            f"oldest entry {cache_stats['oldest_entry_days']} days"
+        )
+
         # Get or create target playlist
         playlist_id = api.get_or_create_playlist(
-            playlist_id=config['playlist_id'],
-            playlist_name=config['playlist_name'],
-            privacy_status=config['playlist_visibility']
+            playlist_id=config["playlist_id"],
+            playlist_name=config["playlist_name"],
+            privacy_status=config["playlist_visibility"],
         )
-        
+
         if not playlist_id:
             logger.error("Failed to get or create target playlist")
             sys.exit(1)
-        
+
         # Fetch recent subscription videos
-        published_after = get_published_after_timestamp(config['lookback_hours'])
+        published_after = get_published_after_timestamp(config["lookback_hours"])
         logger.info(f"Fetching videos published after {published_after}")
-        
+
         videos = api.get_subscription_activity(
-            published_after=published_after,
-            max_results=config['max_videos']
+            published_after=published_after, max_results=config["max_videos"]
         )
-        
+
         if not videos:
             logger.info("No recent subscription videos found")
             sys.exit(0)
-        
+
         # Filter videos based on criteria
         filtered_videos = filter_videos(
             videos=videos,
             config=config,
             cache=cache,
-            channel_whitelist=config['channel_whitelist']
+            channel_whitelist=config["channel_whitelist"],
         )
-        
+
         if not filtered_videos:
             logger.info("No videos passed filters")
             sys.exit(0)
-        
+
         # Add videos to playlist
         results = add_videos_to_playlist(
             api=api,
             playlist_id=playlist_id,
             videos=filtered_videos,
             cache=cache,
-            dry_run=args.dry_run
+            dry_run=args.dry_run,
         )
-        
+
         # Summary
         successful = sum(results.values())
         total = len(results)
-        
+
         if args.dry_run:
             logger.info(f"DRY RUN complete: {total} videos would be added")
         else:
-            logger.info(f"Processing complete: {successful}/{total} videos added successfully")
-            
+            logger.info(
+                f"Processing complete: {successful}/{total} videos added successfully"
+            )
+
             if successful < total:
                 logger.warning(f"{total - successful} videos failed to add")
                 sys.exit(1)
-    
+
     except KeyboardInterrupt:
         logger.info("Interrupted by user")
         sys.exit(130)
-    
+
     except SystemExit:
         # Re-raise SystemExit (from authentication failures, etc.)
         raise
-    
+
     except Exception as e:
         logger.error(f"Unexpected error: {e}")
         if args.verbose:
@@ -287,5 +312,5 @@ Examples:
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -1,6 +1,8 @@
 import logging
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
+
 from googleapiclient.errors import HttpError
+
 from auth import get_authenticated_service
 from utils import parse_duration_to_seconds
 
@@ -12,141 +14,151 @@ class YouTubeAPI:
     Wrapper for YouTube Data API v3 with methods specific to playlist automation.
     Handles API calls, error handling, and data transformation.
     """
-    
+
     def __init__(self):
         self.service = get_authenticated_service()
-    
-    def get_subscription_activity(self, published_after: str, max_results: int = 50) -> List[Dict[str, Any]]:
+
+    def get_subscription_activity(
+        self, published_after: str, max_results: int = 50
+    ) -> List[Dict[str, Any]]:
         """
         Get recent videos from subscribed channels using the activities endpoint.
         This is more efficient than fetching each channel individually.
-        
+
         Args:
             published_after: RFC 3339 timestamp for filtering recent videos
             max_results: Maximum number of activities to fetch (default 50, max 50)
-            
+
         Returns:
-            List of video data dictionaries with keys: video_id, title, channel_id, 
-            channel_title, published_at, duration_seconds
+            List of video data dictionaries with keys: video_id, title, channel_id,
+            channel_title, published_at, duration_seconds, live_broadcast
         """
         videos = []
-        
+
         try:
             # Get subscription activities (uploads from subscribed channels)
             request = self.service.activities().list(
-                part='snippet,contentDetails',
+                part="snippet,contentDetails",
                 home=True,
                 publishedAfter=published_after,
-                maxResults=min(max_results, 50)  # API limit is 50
+                maxResults=min(max_results, 50),  # API limit is 50
             )
-            
+
             response = request.execute()
-            
-            if 'items' not in response:
+
+            if "items" not in response:
                 logger.warning("No activities found in API response")
                 return videos
-            
+
             # Extract video IDs for batch duration lookup
             video_ids = []
             activity_map = {}
-            
-            for item in response['items']:
+
+            for item in response["items"]:
                 # Only process upload activities
-                if (item['snippet']['type'] == 'upload' and 
-                    'upload' in item.get('contentDetails', {})):
-                    
-                    video_id = item['contentDetails']['upload']['videoId']
+                if item["snippet"]["type"] == "upload" and "upload" in item.get(
+                    "contentDetails", {}
+                ):
+
+                    video_id = item["contentDetails"]["upload"]["videoId"]
                     video_ids.append(video_id)
                     activity_map[video_id] = item
-            
+
             if not video_ids:
                 logger.info("No upload activities found in recent subscriptions")
                 return videos
-            
+
             # Batch fetch video details including duration
             videos_details = self._get_videos_details(video_ids)
-            
+
             # Combine activity data with video details
             for video_id, details in videos_details.items():
                 if video_id in activity_map:
                     activity = activity_map[video_id]
-                    
+
                     video_data = {
-                        'video_id': video_id,
-                        'title': activity['snippet']['title'],
-                        'channel_id': activity['snippet']['channelId'],
-                        'channel_title': activity['snippet']['channelTitle'],
-                        'published_at': activity['snippet']['publishedAt'],
-                        'duration_seconds': parse_duration_to_seconds(
-                            details.get('duration', '')
-                        )
+                        "video_id": video_id,
+                        "title": activity["snippet"]["title"],
+                        "channel_id": activity["snippet"]["channelId"],
+                        "channel_title": activity["snippet"]["channelTitle"],
+                        "published_at": activity["snippet"]["publishedAt"],
+                        "duration_seconds": parse_duration_to_seconds(
+                            details.get("duration", "")
+                        ),
+                        "live_broadcast": details.get("liveBroadcastContent", "none"),
                     }
                     videos.append(video_data)
-            
+
             logger.info(f"Found {len(videos)} recent videos from subscriptions")
             return videos
-            
+
         except HttpError as e:
             logger.error(f"YouTube API error fetching subscription activity: {e}")
             return []
         except Exception as e:
             logger.error(f"Unexpected error fetching subscription activity: {e}")
             return []
-    
+
     def _get_videos_details(self, video_ids: List[str]) -> Dict[str, Dict[str, Any]]:
         """
-        Fetch video details including duration for a batch of video IDs.
-        
+        Fetch video details including duration and live broadcast status for a batch of video IDs.
+
         Args:
             video_ids: List of YouTube video IDs
-            
+
         Returns:
-            Dict mapping video_id to details dict with 'duration' key
+            Dict mapping video_id to details dict with 'duration' and 'liveBroadcastContent' keys
         """
         details = {}
-        
+
         if not video_ids:
             return details
-        
+
         try:
             # YouTube API allows up to 50 IDs per request
             batch_size = 50
             for i in range(0, len(video_ids), batch_size):
-                batch = video_ids[i:i + batch_size]
-                
+                batch = video_ids[i : i + batch_size]
+
                 request = self.service.videos().list(
-                    part='contentDetails',
-                    id=','.join(batch)
+                    part="contentDetails,snippet", id=",".join(batch)
                 )
-                
+
                 response = request.execute()
-                
-                for item in response.get('items', []):
-                    video_id = item['id']
-                    duration = item['contentDetails']['duration']
-                    details[video_id] = {'duration': duration}
-            
+
+                for item in response.get("items", []):
+                    video_id = item["id"]
+                    duration = item["contentDetails"]["duration"]
+                    live_broadcast_content = item["snippet"].get("liveBroadcastContent", "none")
+                    details[video_id] = {
+                        "duration": duration,
+                        "liveBroadcastContent": live_broadcast_content
+                    }
+
             logger.debug(f"Fetched details for {len(details)} videos")
             return details
-            
+
         except HttpError as e:
             logger.error(f"YouTube API error fetching video details: {e}")
             return {}
         except Exception as e:
             logger.error(f"Unexpected error fetching video details: {e}")
             return {}
-    
-    def get_or_create_playlist(self, playlist_id: Optional[str], 
-                              playlist_name: str = "Auto Playlist from Subscriptions",
-                              privacy_status: str = "unlisted") -> Optional[str]:
+
+    def get_or_create_playlist(
+        self,
+        playlist_id: Optional[str],
+        playlist_name: str = "Auto Playlist from Subscriptions",
+        privacy_status: str = "unlisted",
+    ) -> Optional[str]:
         """
         Get existing playlist or create a new one if it doesn't exist.
-        
+
         Args:
             playlist_id: Existing playlist ID, or None to create new
             playlist_name: Name for new playlist if creation is needed
             privacy_status: Privacy setting (public, private, unlisted)
-            
+
         Returns:
             Playlist ID if successful, None if failed
         """
@@ -157,86 +169,76 @@ class YouTubeAPI:
                 return playlist_id
             else:
                 logger.warning(f"Playlist {playlist_id} not found or inaccessible")
-        
+
         # Create new playlist
         return self._create_playlist(playlist_name, privacy_status)
-    
+
     def _verify_playlist_exists(self, playlist_id: str) -> bool:
         """Check if playlist exists and is accessible."""
         try:
-            request = self.service.playlists().list(
-                part='snippet',
-                id=playlist_id
-            )
+            request = self.service.playlists().list(part="snippet", id=playlist_id)
             response = request.execute()
-            return len(response.get('items', [])) > 0
-            
+            return len(response.get("items", [])) > 0
+
         except HttpError as e:
             logger.debug(f"Error verifying playlist {playlist_id}: {e}")
             return False
-    
+
     def _create_playlist(self, title: str, privacy_status: str) -> Optional[str]:
         """Create a new playlist."""
         try:
             playlist_body = {
-                'snippet': {
-                    'title': title,
-                    'description': 'Automatically generated playlist from subscription videos'
+                "snippet": {
+                    "title": title,
+                    "description": "Automatically generated playlist from subscription videos",
                 },
-                'status': {
-                    'privacyStatus': privacy_status
-                }
+                "status": {"privacyStatus": privacy_status},
             }
-            
+
             request = self.service.playlists().insert(
-                part='snippet,status',
-                body=playlist_body
+                part="snippet,status", body=playlist_body
             )
-            
+
             response = request.execute()
-            playlist_id = response['id']
-            
+            playlist_id = response["id"]
+
             logger.info(f"Created new playlist '{title}' with ID: {playlist_id}")
             return playlist_id
-            
+
         except HttpError as e:
             logger.error(f"Failed to create playlist: {e}")
             return None
         except Exception as e:
             logger.error(f"Unexpected error creating playlist: {e}")
             return None
-    
+
     def add_video_to_playlist(self, playlist_id: str, video_id: str) -> bool:
         """
         Add a single video to a playlist.
-        
+
         Args:
             playlist_id: Target playlist ID
             video_id: YouTube video ID to add
-            
+
         Returns:
             True if successful, False otherwise
         """
         try:
             playlist_item_body = {
-                'snippet': {
-                    'playlistId': playlist_id,
-                    'resourceId': {
-                        'kind': 'youtube#video',
-                        'videoId': video_id
-                    }
+                "snippet": {
+                    "playlistId": playlist_id,
+                    "resourceId": {"kind": "youtube#video", "videoId": video_id},
                 }
             }
-            
+
             request = self.service.playlistItems().insert(
-                part='snippet',
-                body=playlist_item_body
+                part="snippet", body=playlist_item_body
             )
-            
+
             response = request.execute()
             logger.debug(f"Added video {video_id} to playlist {playlist_id}")
             return True
-            
+
         except HttpError as e:
             # Handle common errors gracefully
             if e.resp.status == 409:
@@ -248,27 +250,31 @@ class YouTubeAPI:
         except Exception as e:
             logger.warning(f"Unexpected error adding video {video_id} to playlist: {e}")
             return False
-    
-    def add_videos_to_playlist(self, playlist_id: str, video_ids: List[str]) -> Dict[str, bool]:
+
+    def add_videos_to_playlist(
+        self, playlist_id: str, video_ids: List[str]
+    ) -> Dict[str, bool]:
         """
         Add multiple videos to a playlist.
-        
+
         Args:
             playlist_id: Target playlist ID
             video_ids: List of YouTube video IDs to add
-            
+
         Returns:
             Dict mapping video_id to success status (True/False)
         """
         results = {}
-        
+
         for video_id in video_ids:
             success = self.add_video_to_playlist(playlist_id, video_id)
             results[video_id] = success
-        
+
         successful = sum(results.values())
-        logger.info(f"Successfully added {successful}/{len(video_ids)} videos to playlist")
-        
+        logger.info(
+            f"Successfully added {successful}/{len(video_ids)} videos to playlist"
+        )
+
         return results
 
 
@@ -276,35 +282,38 @@ if __name__ == "__main__":
     # Simple test to verify API functionality
     import os
     from datetime import datetime, timedelta
-    from utils import setup_logging, get_published_after_timestamp
-    
+
+    from utils import get_published_after_timestamp, setup_logging
+
     setup_logging(verbose=True)
-    
+
     try:
         api = YouTubeAPI()
-        
+
         # Test fetching recent subscription activity
         print("Testing subscription activity fetch...")
         published_after = get_published_after_timestamp(24)
         videos = api.get_subscription_activity(published_after, max_results=5)
-        
+
         print(f"Found {len(videos)} recent videos:")
         for video in videos[:3]:  # Show first 3
-            print(f"  - {video['title']} ({video['duration_seconds']}s) by {video['channel_title']}")
-        
+            print(
+                f"  - {video['title']} ({video['duration_seconds']}s) by {video['channel_title']}"
+            )
+
         # Test playlist verification (will fail gracefully if no playlist ID provided)
         print("\nTesting playlist operations...")
         test_playlist = api.get_or_create_playlist(
             playlist_id=None,  # Will create a new test playlist
             playlist_name="Test Playlist from Script",
-            privacy_status="private"
+            privacy_status="private",
         )
-        
+
         if test_playlist:
             print(f"✅ Playlist ready: {test_playlist}")
         else:
             print("❌ Failed to get/create playlist")
-            
+
     except SystemExit:
         print("❌ Authentication failed")
     except Exception as e:


### PR DESCRIPTION
- Updated YouTube API calls to extract `liveBroadcastContent` from video metadata
- Extended video schema with `live_broadcast` field (`live` | `upcoming` | `none`)
- Added `SKIP_LIVE_CONTENT` env flag (default: `true`) to control filtering behavior
- Implemented filtering logic in `main.py` to exclude livestreams and premieres
- Logged skipped content with reasons ("Skipping livestream", "Skipping premiere")
- Updated `.env.example` with documented `SKIP_LIVE_CONTENT` config
- Preserves backwards compatibility and respects dry-run logic