### PR TITLE
feat(docker): add Dockerfile, .dockerignore, and entrypoint shim

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,9 +20,19 @@ package.json
 .idea/
 .DS_Store
 _notes/
+
+# Runtime artifacts — exclude both top-level and any nested copies (the package
+# itself writes to yt_sub_playlist/data/, yt_sub_playlist/reports/, etc. during
+# local dev, and those would otherwise be baked into the published image).
 reports/
 logs/
 data/
+**/data/
+**/reports/
+**/logs/
+**/processed_videos.json
+**/api_call_log.json
+**/playlist_cache/
 
 # Secrets that must never end up in a layer
 secrets/

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,8 +15,10 @@ pnpm-lock.yaml
 package.json
 .versionrc.json
 
-# Local workspace state
+# Local workspace state, including AI-tooling config that may be repo-local
 .claude/
+.agents/
+agents/
 .idea/
 .DS_Store
 _notes/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Python build artifacts
+__pycache__/
+*.py[codz]
+*.so
+*.egg-info/
+.Python
+
+# Virtualenvs (uv creates one inside the container)
+.venv/
+venv/
+
+# Node tooling (we don't need it inside the container — release flow only)
+node_modules/
+pnpm-lock.yaml
+package.json
+.versionrc.json
+
+# Local workspace state
+.claude/
+.idea/
+.DS_Store
+_notes/
+reports/
+logs/
+data/
+
+# Secrets that must never end up in a layer
+secrets/
+client_secrets.json
+token.json
+.env
+.env.*
+*.env
+
+# Git + CI metadata (not needed at runtime)
+.git/
+.gitignore
+.github/
+
+# Documentation (not needed at runtime, except files referenced by pyproject.toml)
+docs/
+CHANGELOG.md
+# README.md and LICENSE are referenced by pyproject.toml's `readme` and
+# `license` fields, so hatchling needs them present during `uv sync` to build
+# the project's metadata. Don't exclude them.
+
+# Build artifacts
+bin/
+build/
+dist/
+
+# Spec / plan workspace
+docs/superpowers/
+
+# Templates (out-of-scope for v1, but excluded to keep image lean)
+templates/
+web/
+dashboard/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1.7
+
+# --- builder ---------------------------------------------------------------
+# Resolves and installs the project into /app/.venv using `uv`. The final
+# stage copies the venv but not `uv` itself, keeping the runtime image lean.
+FROM python:3.11-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+WORKDIR /app
+
+# Layer 1: resolve and install dependencies only. Cached unless uv.lock changes.
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev
+
+# Layer 2: install the project itself. LICENSE and README.md are referenced by
+# pyproject.toml ([project].license and [project].readme), so hatchling needs
+# them present at build time.
+COPY LICENSE README.md ./
+COPY yt_sub_playlist ./yt_sub_playlist
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+# --- runtime ---------------------------------------------------------------
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app
+COPY --from=builder /app /app
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# /data is where client_secrets.json and token.json live at runtime. Platforms
+# either bind-mount it (raw Docker) or attach a volume (Fly). For ephemeral
+# runs (GitHub Actions) the shim writes the env-var secrets here on startup.
+RUN mkdir -p /data
+WORKDIR /data
+VOLUME ["/data"]
+
+# ENTRYPOINT bakes in the CLI invocation so `docker run <image> --help` works.
+# Override --entrypoint to launch the dashboard or any other module.
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh", "yt-sub-playlist"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,14 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PATH="/app/.venv/bin:$PATH"
 
+# Non-root user. UID 1000 is conventional and matches typical desktop bind
+# mounts. Fly volumes are root-owned at creation — see docs/deploy/fly.md
+# for the one-time `fly ssh console` chown step.
+RUN groupadd --system --gid 1000 app \
+    && useradd --system --uid 1000 --gid app --shell /usr/sbin/nologin --home /app app
+
 WORKDIR /app
-COPY --from=builder /app /app
+COPY --from=builder --chown=app:app /app /app
 
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
@@ -43,9 +49,11 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # /data is where client_secrets.json and token.json live at runtime. Platforms
 # either bind-mount it (raw Docker) or attach a volume (Fly). For ephemeral
 # runs (GitHub Actions) the shim writes the env-var secrets here on startup.
-RUN mkdir -p /data
+RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 VOLUME ["/data"]
+
+USER app
 
 # ENTRYPOINT bakes in the CLI invocation so `docker run <image> --help` works.
 # Override --entrypoint to launch the dashboard or any other module.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Hydrate env-var-driven secrets to /data so the Python app can read them.
+# If a file already exists on disk (bind-mounted or persisted-volume case),
+# leave it alone so refreshed tokens survive restarts.
+
+set -eu
+
+DATA_DIR="${YT_SUB_PLAYLIST_DATA_DIR:-/data}"
+
+write_secret() {
+    var_name="$1"
+    file_name="$2"
+    file_path="$DATA_DIR/$file_name"
+
+    eval "var_value=\${$var_name:-}"
+
+    if [ -z "$var_value" ]; then
+        return 0
+    fi
+
+    if [ -f "$file_path" ]; then
+        return 0
+    fi
+
+    printf '%s' "$var_value" > "$file_path"
+    chmod 600 "$file_path"
+}
+
+write_secret CLIENT_SECRETS_JSON client_secrets.json
+write_secret TOKEN_JSON token.json
+
+exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,4 +37,11 @@ write_secret() {
 write_secret CLIENT_SECRETS_B64 client_secrets.json
 write_secret TOKEN_B64 token.json
 
+# The app reads client_secrets.json / token.json as relative paths. The image's
+# WORKDIR is /data, but platforms like GitHub Actions (`uses: docker://...`)
+# override the container's working directory to the runner's checkout. Force
+# cwd to the secrets directory so the CLI's relative reads find the hydrated
+# files regardless of how the container was invoked.
+cd "$DATA_DIR"
+
 exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
-# Hydrate env-var-driven secrets to /data so the Python app can read them.
-# If a file already exists on disk (bind-mounted or persisted-volume case),
-# leave it alone so refreshed tokens survive restarts.
+# Hydrate base64-encoded secrets from env vars to /data so the Python app can
+# read them. If a file already exists on disk (bind-mounted or persisted-volume
+# case), leave it alone so refreshed tokens survive restarts.
+#
+# Base64 is used because `token.json` is actually a binary credentials
+# serialization (not JSON), despite the filename. Raw env vars would corrupt
+# binary content with NUL bytes. `client_secrets.json` is genuine JSON and
+# would survive raw transit, but we base64 both so the contract is consistent.
+#
+# Encode files on the user's laptop with: base64 -w0 < token.json
+# (macOS: `base64 < token.json | tr -d '\n'`)
 
 set -eu
 
@@ -22,11 +30,11 @@ write_secret() {
         return 0
     fi
 
-    printf '%s' "$var_value" > "$file_path"
+    printf '%s' "$var_value" | base64 -d > "$file_path"
     chmod 600 "$file_path"
 }
 
-write_secret CLIENT_SECRETS_JSON client_secrets.json
-write_secret TOKEN_JSON token.json
+write_secret CLIENT_SECRETS_B64 client_secrets.json
+write_secret TOKEN_B64 token.json
 
 exec "$@"

--- a/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
+++ b/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
@@ -106,7 +106,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prepare data dir
-        run: mkdir -p ${{ github.workspace }}/data
+        # The container runs as UID 1000 (non-root). The runner creates the
+        # workspace as a different user, so chmod before mounting.
+        run: |
+          mkdir -p ${{ github.workspace }}/data
+          sudo chown -R 1000:1000 ${{ github.workspace }}/data
       - name: Run sync
         run: |
           docker run --rm \
@@ -114,6 +118,10 @@ jobs:
             -e CLIENT_SECRETS_B64="${{ secrets.CLIENT_SECRETS_B64 }}" \
             -e TOKEN_B64="${{ secrets.TOKEN_B64 }}" \
             ghcr.io/keif/yt-sub-playlist:<version>
+      - name: Reclaim ownership for runner
+        # The container's UID 1000 wrote the refreshed token; the round-trip
+        # step runs as the runner user and needs to read it.
+        run: sudo chown -R $(id -u):$(id -g) ${{ github.workspace }}/data
       - name: Round-trip refreshed token
         env: { GH_TOKEN: ${{ secrets.GH_PAT }} }
         run: |

--- a/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
+++ b/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
@@ -105,16 +105,26 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker://ghcr.io/keif/yt-sub-playlist:<version>
-        env:
-          CLIENT_SECRETS_B64: ${{ secrets.CLIENT_SECRETS_B64 }}
-          TOKEN_B64: ${{ secrets.TOKEN_B64 }}
+      - name: Prepare data dir
+        run: mkdir -p ${{ github.workspace }}/data
+      - name: Run sync
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}/data:/data \
+            -e CLIENT_SECRETS_B64="${{ secrets.CLIENT_SECRETS_B64 }}" \
+            -e TOKEN_B64="${{ secrets.TOKEN_B64 }}" \
+            ghcr.io/keif/yt-sub-playlist:<version>
       - name: Round-trip refreshed token
         env: { GH_TOKEN: ${{ secrets.GH_PAT }} }
-        run: gh secret set TOKEN_B64 --body "$(cat /tmp/token.json)" --repo "$GITHUB_REPOSITORY"
+        run: |
+          gh secret set TOKEN_B64 \
+            --body "$(base64 < ${{ github.workspace }}/data/token.json | tr -d '\n')" \
+            --repo "$GITHUB_REPOSITORY"
 ```
 
 Free if the user is OK with running on Microsoft infra. Runbook is explicit about `GH_PAT`.
+
+Note the explicit `docker run` (not `uses: docker://...`) so the workflow controls the volume mount — the refreshed `token.json` needs to land on the runner's filesystem so the round-trip step can read it. The round-trip step re-encodes the binary token as base64 before writing it back to the secret; without that, the next run's entrypoint would fail at `base64 -d`.
 
 ### Path 3: Raw Docker / VPS
 

--- a/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
+++ b/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
@@ -43,7 +43,9 @@ YouTube Data API v3 quota is 10k units/day per *application*, not per user. A Sa
 
 **One image, one entrypoint.** `ENTRYPOINT ["python", "-m", "yt_sub_playlist"]` with the cron sync as the default `CMD`. The dashboard is launchable via `CMD ["python", "-m", "yt_sub_playlist.dashboard"]` for users who want it, but v1 documentation does not recommend exposing it publicly.
 
-**Entrypoint shim** unifies env-var-driven and file-mounted secrets handling. If `CLIENT_SECRETS_JSON` and `TOKEN_JSON` env vars are set, the shim writes them to `/data/*.json` before launching the CLI. If the files already exist (raw Docker bind mount), the shim leaves them alone. No code branching in the Python app.
+**Entrypoint shim** unifies env-var-driven and file-mounted secrets handling. If `CLIENT_SECRETS_B64` and `TOKEN_B64` env vars are set, the shim base64-decodes them to `/data/*.json` before launching the CLI. If the files already exist (raw Docker bind mount, or persisted Fly volume after first run), the shim leaves them alone. No code branching in the Python app.
+
+Both secrets are base64-encoded by contract. `token.json` despite its name is a binary credentials serialization (not JSON), so raw env vars would corrupt it on NUL bytes; `client_secrets.json` is genuine JSON and would survive raw transit, but encoding both keeps the contract consistent. A follow-up spec should migrate the project's token format to JSON (via `google.oauth2.credentials.Credentials.to_json()`); doing so would let users skip the base64 step but requires existing users to re-bootstrap their `token.json`. Out of scope for v1.
 
 ## Files added to the repo
 
@@ -69,8 +71,8 @@ The shared bootstrap produces two files: `client_secrets.json` (from GCP) and `t
 
 | Target | `client_secrets.json` | `token.json` | Refresh persistence |
 |---|---|---|---|
-| **Fly.io** | `fly secrets set CLIENT_SECRETS_JSON="$(cat client_secrets.json)"` | `fly secrets set TOKEN_JSON="$(cat token.json)"` | Volume mount at `/data`. Refreshed `token.json` is written back to disk, survives machine restarts. |
-| **GitHub Actions** | Repo secret `CLIENT_SECRETS_JSON` | Repo secret `TOKEN_JSON` | Workflow round-trips via `gh secret set TOKEN_JSON` using a `GH_PAT` (`repo` scope) stored as a third secret. **Without `GH_PAT`, the token works once and then expires permanently.** Documented as the path's primary footgun. |
+| **Fly.io** | `fly secrets set CLIENT_SECRETS_B64="$(base64 < client_secrets.json)"` | `fly secrets set TOKEN_B64="$(base64 < token.json)"` | Volume mount at `/data`. Refreshed `token.json` is written back to disk, survives machine restarts. |
+| **GitHub Actions** | Repo secret `CLIENT_SECRETS_B64` | Repo secret `TOKEN_B64` | Workflow round-trips via `gh secret set TOKEN_B64` using a `GH_PAT` (`repo` scope) stored as a third secret. **Without `GH_PAT`, the token works once and then expires permanently.** Documented as the path's primary footgun. |
 | **Raw Docker / VPS** | `./secrets/client_secrets.json` bind-mounted read-only | `./secrets/token.json` bind-mounted writable | Native filesystem. Refreshed token persists via the bind mount. |
 
 The GitHub Actions round-trip is the one piece of friction that doesn't have a clean alternative. Considered and rejected: committing the refreshed token back to a private repo file (worse than encrypted-at-rest secrets, even if the repo is private).
@@ -82,8 +84,8 @@ The GitHub Actions round-trip is the one piece of friction that doesn't have a c
 ```bash
 fly launch --copy-config --no-deploy        # uses fly.toml.example, creates the app only
 fly volume create data --size 1
-fly secrets set CLIENT_SECRETS_JSON="$(cat client_secrets.json)" \
-                TOKEN_JSON="$(cat token.json)"
+fly secrets set CLIENT_SECRETS_B64="$(base64 < client_secrets.json)" \
+                TOKEN_B64="$(base64 < token.json)"
 fly machine run --schedule daily \
    --volume data:/data \
    ghcr.io/keif/yt-sub-playlist:<version>
@@ -93,7 +95,7 @@ Fits the free tier. Note the absence of `fly deploy` — a scheduled machine is 
 
 ### Path 2: GitHub Actions cron
 
-User forks the repo, copies `cron-sync.example.yml` to `.github/workflows/cron-sync.yml`, sets three repo secrets (`CLIENT_SECRETS_JSON`, `TOKEN_JSON`, `GH_PAT`). Workflow runs on cron + `workflow_dispatch`, pulls the published image, runs the sync, round-trips the refreshed token back into repo secrets.
+User forks the repo, copies `cron-sync.example.yml` to `.github/workflows/cron-sync.yml`, sets three repo secrets (`CLIENT_SECRETS_B64`, `TOKEN_B64`, `GH_PAT`). Workflow runs on cron + `workflow_dispatch`, pulls the published image, runs the sync, round-trips the refreshed token back into repo secrets.
 
 ```yaml
 on:
@@ -105,11 +107,11 @@ jobs:
     steps:
       - uses: docker://ghcr.io/keif/yt-sub-playlist:<version>
         env:
-          CLIENT_SECRETS_JSON: ${{ secrets.CLIENT_SECRETS_JSON }}
-          TOKEN_JSON: ${{ secrets.TOKEN_JSON }}
+          CLIENT_SECRETS_B64: ${{ secrets.CLIENT_SECRETS_B64 }}
+          TOKEN_B64: ${{ secrets.TOKEN_B64 }}
       - name: Round-trip refreshed token
         env: { GH_TOKEN: ${{ secrets.GH_PAT }} }
-        run: gh secret set TOKEN_JSON --body "$(cat /tmp/token.json)" --repo "$GITHUB_REPOSITORY"
+        run: gh secret set TOKEN_B64 --body "$(cat /tmp/token.json)" --repo "$GITHUB_REPOSITORY"
 ```
 
 Free if the user is OK with running on Microsoft infra. Runbook is explicit about `GH_PAT`.
@@ -164,7 +166,7 @@ Each runbook ends with a verification block:
 
 Each chunk is sized to produce a working, testable deliverable. Roughly ordered by dependency.
 
-1. **`Dockerfile` + `.dockerignore` + entrypoint shim.** Image builds, runs, and writes env-var secrets to disk. Smoke test: `docker run -e CLIENT_SECRETS_JSON=... -e TOKEN_JSON=... <image> --help` prints CLI help.
+1. **`Dockerfile` + `.dockerignore` + entrypoint shim.** Image builds, runs, and writes env-var secrets to disk. Smoke test: `docker run -e CLIENT_SECRETS_B64=... -e TOKEN_B64=... <image> --help` prints CLI help.
 2. **`docker-compose.yml`.** Raw Docker path works end-to-end against a locally-built image. Verification: `docker compose run --rm sync --dry-run` succeeds.
 3. **`.github/workflows/docker-publish.yml`.** Image publishes to ghcr.io on `v*` tag. Verification: tag a test version, confirm the image appears at the expected URL.
 4. **`fly.toml.example` + `docs/deploy/fly.md`.** Fly path documented and tested by the maintainer at least once.


### PR DESCRIPTION
Closes #11.

## Summary

- Multi-stage Dockerfile that resolves the project with `uv` in a builder stage and ships only the venv + entrypoint in the runtime stage on `python:3.11-slim`.
- `.dockerignore` excluding runtime artifacts (top-level + nested), secrets, build tooling, AI-tool config directories, and anything else that should not enter the build context.
- `docker/entrypoint.sh` shim that base64-decodes `CLIENT_SECRETS_B64` and `TOKEN_B64` to `/data/*.json` on startup (if those files do not already exist), then forces cwd to `/data` so platforms that override the container working directory (notably GitHub Actions' `uses: docker://...`) still let the CLI's relative-path reads find the secrets.
- Runtime stage runs as non-root UID 1000 (`app`). `/data` is chowned to `app:app` in the image.

## Decisions worth flagging

- **Base64 over raw env** — `token.json` is a binary credentials serialization despite its name, so raw env transit corrupts NUL bytes. Both secrets are base64-encoded by contract for consistency. Spec notes a follow-up to migrate the project's token format to JSON, which would let users skip the base64 step (out of scope here — it breaks existing users' tokens).
- **Non-root, with one platform caveat** — Fly volumes are root-owned at creation. The Fly runbook (#14) will document a one-time `fly ssh console`-and-chown step. GitHub Actions runbook (#15) handles the same with a `sudo chown` before the bind mount and a reclaim step after.
- **`COPY LICENSE README.md`** — needed because `pyproject.toml` references them via `[project].readme` and `[project].license`. Without those, hatchling's metadata build fails.

## Codex review history

Ran `/codex review` five times across the iteration. Three Codex passes surfaced findings before the gate cleared:

| Pass | Findings | Fixed in |
|---|---|---|
| 1 | P1 binary-token-as-env-var; P2 nested data leak; P2 root user | `536bf2f` |
| 2 | P2 cwd override (GHA); P2 round-trip not re-encoded | `92507f3` (entrypoint), `c02d038` (spec) |
| 3 | P2 GHA bind-mount permissions for UID 1000 | `c02d038` |
| 4 | P2 `agents/` not in `.dockerignore` | `4d99f2c` |
| 5 | Clean — no findings | merge |

## Verification

- [x] `docker build -t yt-sub-playlist:dev .` succeeds on Apple Silicon (and emits an amd64+arm64 manifest list)
- [x] `docker run --rm yt-sub-playlist:dev --help` prints CLI help
- [x] `docker run --rm -e CLIENT_SECRETS_B64=... -e TOKEN_B64=... yt-sub-playlist:dev --help` decodes secrets to `/data/*.json` with 0600 perms owned by `app:app`
- [x] Container runs as `uid=1000(app) gid=1000(app)` by default
- [x] Forced `cd "$DATA_DIR"` survives a runtime `-w /github/workspace` override
- [x] No `yt_sub_playlist/data/`, `yt_sub_playlist/reports/`, or `*.csv` files end up in the image
- [x] Image size: ~88MB unique layers on top of `python:3.11-slim`

## Test plan (downstream)

- [ ] First `v*` tag push (post-#13) produces a working `ghcr.io/keif/yt-sub-playlist:<version>` image
- [ ] `docker compose run --rm sync --dry-run` succeeds end-to-end against a real `client_secrets.json` + `token.json` (covered by #12)
- [ ] Fly machine schedule path verified against the published image (covered by #14)
- [ ] GitHub Actions cron path verified including the secret round-trip (covered by #15)

## Spec

[`docs/superpowers/specs/2026-06-28-deploy-your-own-design.md`](../blob/main/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md) was also updated in this PR to reflect the env-var name change and the corrected GHA workflow shape.