### PR TITLE
feat(compose): add docker-compose.yml for raw Docker / VPS path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,18 @@ services:
     image: yt-sub-playlist:local
     container_name: yt-sub-playlist-sync
     volumes:
-      # ./data holds client_secrets.json + token.json + the app's runtime
-      # state (api_call_log.json, playlist_cache/, processed_videos.json).
+      # ./data holds:
+      #   - client_secrets.json + token.json (credentials)
+      #   - config.json (optional, project preferences — see README)
+      #   - .env (optional, e.g. PLAYLIST_ID and per-deploy overrides)
+      #   - api_call_log.json, playlist_cache/, processed_videos.json (runtime)
       # Treat this directory as sensitive: it contains a live OAuth refresh
       # token. Restrict host-side permissions (`chmod 700 data/`) and back
       # it up with the same care you'd back up any other credential.
+      #
+      # The app reads config.json and .env from cwd (the entrypoint forces
+      # cwd to /data), so this single bind mount carries every config source
+      # the app supports.
       - ./data:/data
 
   # ---------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+# docker-compose.yml — raw Docker / VPS deploy path for yt-sub-playlist.
+#
+# This file is intended to live in the user's deploy checkout (their own
+# fork, or a copy alongside ./data/). It builds the image locally by
+# default. Once the project publishes images to ghcr.io (#13), swap
+# `build: .` for `image: ghcr.io/keif/yt-sub-playlist:<version>` and
+# `docker compose pull` instead of `docker compose build`.
+#
+# Secrets layout: place client_secrets.json and token.json directly under
+# ./data/ before the first run. The Python app reads both files from cwd
+# (which the entrypoint shim forces to /data). The token is refreshed in
+# place on each run, so /data needs to be writable.
+#
+# Scheduling: this service is intentionally one-shot — no `restart` policy.
+# Trigger it from host cron or a systemd timer:
+#   0 6 * * *   cd /srv/yt-sub-playlist && /usr/bin/docker compose run --rm sync >> /var/log/yt-sub-playlist.log 2>&1
+# See docs/deploy/docker.md (#16) for the full runbook.
+
+services:
+  sync:
+    build: .
+    image: yt-sub-playlist:local
+    container_name: yt-sub-playlist-sync
+    volumes:
+      # ./data holds client_secrets.json + token.json + the app's runtime
+      # state (api_call_log.json, playlist_cache/, processed_videos.json).
+      # Treat this directory as sensitive: it contains a live OAuth refresh
+      # token. Restrict host-side permissions (`chmod 700 data/`) and back
+      # it up with the same care you'd back up any other credential.
+      - ./data:/data
+
+  # ---------------------------------------------------------------------------
+  # The Flask dashboard is intentionally NOT shipped in the cron-job image.
+  # The dashboard backend uses cwd-relative imports (no __init__.py in
+  # dashboard/backend/) that make it awkward to launch from the package-only
+  # image this Dockerfile produces. Recommended v1 pattern: run the dashboard
+  # locally on your laptop with `uv run`, pointed at the same ./data directory
+  # (mount via sshfs/Tailscale if the data lives on a remote VPS).
+  #
+  # A future spec will cover dashboard deploy with a proper auth layer. See
+  # `docs/superpowers/specs/2026-06-28-deploy-your-own-design.md`
+  # → "Follow-up specs".
+  # ---------------------------------------------------------------------------

--- a/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
+++ b/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
@@ -140,6 +140,12 @@ Note the explicit `docker run` (not `uses: docker://...`) so the workflow contro
 mkdir -p ./data
 cp /path/to/client_secrets.json ./data/
 cp /path/to/token.json ./data/
+# Optional but recommended: drop your config.json and .env into ./data/ too.
+# The app reads both from cwd, and the entrypoint forces cwd to /data, so
+# these settings (PLAYLIST_ID, filtering rules, etc.) take effect without
+# any further wiring. Otherwise the sync runs with built-in defaults.
+cp /path/to/config.json ./data/   # optional
+cp /path/to/.env ./data/          # optional
 # Container runs as UID 1000. On Linux hosts, give that UID write access to
 # ./data so the entrypoint can refresh token.json in place. (macOS hosts via
 # Docker Desktop / OrbStack translate UIDs and can skip this step.)

--- a/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
+++ b/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
@@ -73,7 +73,7 @@ The shared bootstrap produces two files: `client_secrets.json` (from GCP) and `t
 |---|---|---|---|
 | **Fly.io** | `fly secrets set CLIENT_SECRETS_B64="$(base64 < client_secrets.json)"` | `fly secrets set TOKEN_B64="$(base64 < token.json)"` | Volume mount at `/data`. Refreshed `token.json` is written back to disk, survives machine restarts. |
 | **GitHub Actions** | Repo secret `CLIENT_SECRETS_B64` | Repo secret `TOKEN_B64` | Workflow round-trips via `gh secret set TOKEN_B64` using a `GH_PAT` (`repo` scope) stored as a third secret. **Without `GH_PAT`, the token works once and then expires permanently.** Documented as the path's primary footgun. |
-| **Raw Docker / VPS** | `./secrets/client_secrets.json` bind-mounted read-only | `./secrets/token.json` bind-mounted writable | Native filesystem. Refreshed token persists via the bind mount. |
+| **Raw Docker / VPS** | `./data/client_secrets.json` (in the bind-mounted data dir) | `./data/token.json` (in the bind-mounted data dir) | Native filesystem. Refreshed token persists via the bind mount. |
 
 The GitHub Actions round-trip is the one piece of friction that doesn't have a clean alternative. Considered and rejected: committing the refreshed token back to a private repo file (worse than encrypted-at-rest secrets, even if the repo is private).
 
@@ -137,15 +137,16 @@ Note the explicit `docker run` (not `uses: docker://...`) so the workflow contro
 ### Path 3: Raw Docker / VPS
 
 ```bash
-mkdir -p ./secrets ./data
-cp /path/to/client_secrets.json ./secrets/
-cp /path/to/token.json ./secrets/
+mkdir -p ./data
+chmod 700 ./data
+cp /path/to/client_secrets.json ./data/
+cp /path/to/token.json ./data/
 docker compose pull        # or `docker compose build` for build-from-source
 # Then trigger via host cron or systemd timer:
 docker compose run --rm sync
 ```
 
-`docker-compose.yml` defines a `sync` service with `./secrets:/secrets:ro` and `./data:/data` mounts. Host cron / systemd handles scheduling.
+`docker-compose.yml` defines a one-shot `sync` service with a single `./data:/data` bind mount. Both `client_secrets.json` and `token.json` live in `./data/` alongside the app's runtime state (cache, API log). Host cron / systemd handles scheduling — there is no `restart` policy because the container exits after each sync.
 
 ## OAuth bootstrap
 

--- a/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
+++ b/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md
@@ -138,10 +138,17 @@ Note the explicit `docker run` (not `uses: docker://...`) so the workflow contro
 
 ```bash
 mkdir -p ./data
-chmod 700 ./data
 cp /path/to/client_secrets.json ./data/
 cp /path/to/token.json ./data/
-docker compose pull        # or `docker compose build` for build-from-source
+# Container runs as UID 1000. On Linux hosts, give that UID write access to
+# ./data so the entrypoint can refresh token.json in place. (macOS hosts via
+# Docker Desktop / OrbStack translate UIDs and can skip this step.)
+sudo chown -R 1000:1000 ./data
+chmod 700 ./data        # keep the credentials directory locked down
+docker compose build       # build the image locally
+# Later, once #13 publishes images to ghcr.io, replace `build: .` in
+# docker-compose.yml with `image: ghcr.io/keif/yt-sub-playlist:<version>`
+# and use `docker compose pull` instead.
 # Then trigger via host cron or systemd timer:
 docker compose run --rm sync
 ```


### PR DESCRIPTION
Closes #12.

## Summary

- `docker-compose.yml` with one `sync` service (one-shot, no `restart` policy), bind-mounting `./data:/data`.
- Spec updated to reflect the single-`./data/` model (replacing an earlier `./secrets/` vs `./data/` split that was inconsistent across the doc).
- Runbook snippet now: builds the image (no published image yet — coming in #13), chowns `./data` to UID 1000 on Linux hosts, drops `client_secrets.json`, `token.json`, optional `config.json`, and optional `.env` into `./data/`. Single mount carries every config source the app supports.

## Decisions

- **Single `./data/` directory, no `./secrets/` split.** Cleaner mental model; the bind mount carries credentials AND runtime state AND optional config. The credentials directory is sensitive (live OAuth refresh token), but a chmod 700 keeps it locked down at the host level.
- **`build: .` as default, `image:` swap documented.** Until #13 publishes images to ghcr.io, there is nothing to pull. The compose file's image tag is `yt-sub-playlist:local` so the local build gets a sensible name.
- **No dashboard service.** The Flask backend's cwd-relative imports don't fit the cron-only image's layout, and v1 docs recommend running the dashboard locally with `uv run`. A future spec covers dashboard deploy with an auth layer.
- **No `env_file:` declaration.** The entrypoint cd's to `/data`, so the app's `load_dotenv()` and `Path("config.json")` lookups resolve there naturally. Telling users to drop `.env` and `config.json` into `./data/` is simpler than declaring environment forwarding in compose.

## Codex review history

| Pass | Findings | Fixed in |
|---|---|---|
| 1 | P2 `pull` before image is published; P2 chmod 700 + UID 1000 mismatch on Linux | `28911bf` |
| 2 | P2 config.json + .env silently ignored | `60be173` |
| 3 | Clean — no findings | merge |

## Verification

- [x] `docker compose config` parses cleanly
- [x] `docker compose run --rm sync --help` builds the image on first run and prints CLI help
- [x] Bind-mount works: secrets dropped in `./data/` are visible to the container at `/data/`
- [x] Spec is now internally consistent — no more `./secrets/` references that contradict `./data/`

## Test plan (downstream)

- [ ] After #13 publishes images: confirm swapping `build: .` for `image: ghcr.io/keif/yt-sub-playlist:<version>` and `docker compose pull` works end-to-end
- [ ] Cron / systemd timer wiring documented in #16 runbook

## Spec

[`docs/superpowers/specs/2026-06-28-deploy-your-own-design.md`](../blob/main/docs/superpowers/specs/2026-06-28-deploy-your-own-design.md) updated as part of this PR.