### PR TITLE
ci(docker): publish container image to ghcr.io on v* tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,66 @@
+name: Publish container image
+
+# Triggered by version tag pushes from `standard-version` (`npm run release`
+# produces tags like `v4.2.0`). Also exposes `workflow_dispatch` so a clean
+# rebuild can be kicked off manually without a version bump.
+#
+# Publishes a multi-arch (amd64 + arm64) image to ghcr.io/<owner>/yt-sub-playlist
+# with the following tags on a `v<semver>` push:
+#   - {{version}}     e.g. 4.2.0
+#   - {{major}}.{{minor}}  e.g. 4.2
+#   - latest          (skipped for pre-releases, e.g. v4.2.0-rc.1)
+#
+# All step inputs use the actions ecosystem (`uses:`), not shell `run:` blocks,
+# so there is no surface for command injection from user-controlled inputs.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for arm64 cross-build on amd64 runner)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/yt-sub-playlist
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+            type=sha,format=short,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,11 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+            # `latest` is published ONLY for release-tag pushes (v* refs that
+            # are not prereleases). A workflow_dispatch run produces a sha-
+            # short tag instead, so manually-triggered rebuilds off a feature
+            # branch can never overwrite the released `latest`.
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
             type=sha,format=short,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push


### PR DESCRIPTION
Closes #13.

## Summary

Adds `.github/workflows/docker-publish.yml` — multi-arch (amd64 + arm64) container build pushed to `ghcr.io/keif/yt-sub-playlist` on `v*` tag pushes. Tags applied via `docker/metadata-action`:

- `{{version}}` — e.g. `4.2.0`
- `{{major}}.{{minor}}` — e.g. `4.2`
- `latest` — release-tag pushes only (prereleases excluded; manual-dispatch runs cannot publish it)
- `sha-{{short}}` — `workflow_dispatch` runs only

GHA cache enabled (`type=gha`) so the uv dep-install layer reuses across runs.

## Decisions

- **Multi-arch via QEMU.** Apple Silicon devs pulling locally, ARM-based VPS hosts, and any future ARM Fly machines all benefit. Cross-build adds ~5 min to first push; cache-from amortizes.
- **No `run:` blocks.** Every step is `uses:`. Dynamic inputs (`github.ref_name`, `github.actor`, etc.) only reach action-input fields, never a shell, so there is no command-injection surface.
- **`latest` is release-gated.** Original draft used a hyphen-substring check to suppress prereleases, but a `workflow_dispatch` from `main` or any feature branch could still have overwritten the released `latest`. The expression now requires `github.event_name == 'push'` AND `startsWith(github.ref, 'refs/tags/v')`. (Caught in codex review.)

## Codex review history

| Pass | Findings | Fixed in |
|---|---|---|
| 1 | P2 `latest` could publish from non-release dispatch | `7118cd5` |

(Second pass scheduled before merge.)

## Verification

- [x] YAML structure validated locally
- [ ] Real test: push a `vtest` tag after merge → confirm image appears at `ghcr.io/keif/yt-sub-playlist:vtest` → delete the tag and the test image
- [ ] First real release tag (next `npm run release`) produces working `:<version>` + `:<major>.<minor>` + `:latest`
- [ ] Pulling anonymously works once the image is set public (default visibility is private on first publish — manual flip via GitHub Packages UI; document in #17's runbooks)

## Test plan (downstream)

- [ ] Runbooks (#14, #15, #16) reference `ghcr.io/keif/yt-sub-playlist:<version>` and will pick up the published image after this lands