### PR TITLE
docs(deploy): add Fly.io runbook and fly.toml.example

### DIFF
--- a/docs/deploy/fly.md
+++ b/docs/deploy/fly.md
@@ -130,20 +130,24 @@ A successful run ends with the playlist manager logging the number of videos
 added and then exiting 0. Look for a line like:
 
 ```
-Sync complete. Added N videos to playlist.
+Processing complete: N/M videos added successfully
 ```
 
 **Confirm token persistence:**
 
-After the first run, inspect the volume to verify `token.json` was refreshed:
+After the first run, inspect the volume to verify `token.json` was refreshed.
+The scheduled machine is stopped (`--restart no`), so use a throwaway alpine
+machine to look at the volume:
 
 ```bash
-fly ssh console
-ls -la /data
-exit
+fly machine run \
+  --rm \
+  --volume data:/data \
+  alpine ls -la /data
 ```
 
-A `token.json` modified after the run confirms the refresh round-trip worked.
+A `token.json` with a mtime newer than when you uploaded it confirms the
+refresh round-trip worked.
 
 ---
 

--- a/docs/deploy/fly.md
+++ b/docs/deploy/fly.md
@@ -50,18 +50,28 @@ state (cache, logs) between daily runs.
 ### 3. Fix volume ownership (one-time)
 
 Fly volumes are created owned by `root`. The container runs as UID 1000 and
-needs write access to `/data` to refresh `token.json` in place. Fix it once:
+the entrypoint shim runs as that non-root user — it cannot write the initial
+`client_secrets.json` / `token.json` to a root-owned volume, so the very first
+scheduled run would fail before it could authenticate. Chown the volume by
+running a throwaway one-shot machine that mounts it and fixes permissions
+before the scheduled job ever runs:
 
 ```bash
-fly ssh console
-chown 1000:1000 /data
-exit
+fly machine run \
+  --rm \
+  --volume data:/data \
+  --entrypoint sh \
+  ghcr.io/keif/yt-sub-playlist:<version> \
+  -c 'chown -R 1000:1000 /data'
 ```
 
-If `fly ssh console` errors because no machine is running yet, skip this step
-and come back after step 5 has run at least once — the entrypoint will write
-files as root the first time. Then do the chown so subsequent refreshes
-(written by UID 1000) succeed.
+The `--rm` flag deletes the chown machine after it exits. The scheduled
+machine in step 5 then attaches the same volume with the corrected ownership.
+
+(Alternatively, after a machine exists — for example after re-running step 5
+following a failed attempt — you can `fly ssh console` into it and run
+`chown -R 1000:1000 /data` interactively. The throwaway-machine flow above
+is preferred because it works from a clean state with no first-run failure.)
 
 ### 4. Upload secrets
 
@@ -83,9 +93,15 @@ the volume and the env-var copy is ignored.
 ```bash
 fly machine run \
   --schedule daily \
+  --restart no \
   --volume data:/data \
   ghcr.io/keif/yt-sub-playlist:<version>
 ```
+
+`--restart no` is important. Without it, Fly defaults to `on-failure` restart,
+which means an expired refresh token or a transient API error would put the
+machine into a tight retry loop (and possibly burn through your YouTube API
+quota) instead of staying stopped until the next daily schedule.
 
 Replace `<version>` with the image tag you want to pin (e.g. `v4.1.0`). See
 [releases](https://github.com/keif/yt-sub-playlist/releases) for available

--- a/docs/deploy/fly.md
+++ b/docs/deploy/fly.md
@@ -1,0 +1,170 @@
+# Fly.io runbook
+
+Run `yt-sub-playlist` as a daily scheduled machine on Fly.io. The machine wakes
+once per day, syncs your playlist, and exits. Fits the Fly.io free tier.
+
+> **No `fly deploy`** — this deploy path uses `fly machine run --schedule`,
+> not `fly deploy`. Running `fly deploy` would create a separate always-on
+> machine that you would be billed for indefinitely. If you ran it by accident,
+> destroy the resulting machine with `fly machine destroy <id>` before
+> continuing.
+
+---
+
+## Prerequisites
+
+- A [Fly.io account](https://fly.io) with `flyctl` installed (`brew install flyctl` or see [fly.io/docs/flyctl/install](https://fly.io/docs/flyctl/install/))
+- `fly auth login` completed
+- `client_secrets.json` and `token.json` on your local machine
+
+  See [docs/deploy/oauth-bootstrap.md](./oauth-bootstrap.md) for the one-time
+  Google Cloud + OAuth setup that produces these two files.
+
+---
+
+## Steps
+
+### 1. Create the app
+
+Copy the example config and launch without deploying:
+
+```bash
+cp fly.toml.example fly.toml
+fly launch --copy-config --no-deploy
+```
+
+`fly launch` registers the app name and region from `fly.toml` but does not
+create any machines. Edit `fly.toml` first to set your preferred `app` name and
+`primary_region`.
+
+### 2. Create the persistent volume
+
+```bash
+fly volume create data --size 1
+```
+
+This creates a 1 GB volume named `data` in your app's primary region. The
+volume persists `client_secrets.json`, `token.json`, and the app's runtime
+state (cache, logs) between daily runs.
+
+### 3. Fix volume ownership (one-time)
+
+Fly volumes are created owned by `root`. The container runs as UID 1000 and
+needs write access to `/data` to refresh `token.json` in place. Fix it once:
+
+```bash
+fly ssh console
+chown 1000:1000 /data
+exit
+```
+
+If `fly ssh console` errors because no machine is running yet, skip this step
+and come back after step 5 has run at least once — the entrypoint will write
+files as root the first time. Then do the chown so subsequent refreshes
+(written by UID 1000) succeed.
+
+### 4. Upload secrets
+
+Base64-encode both credential files and push them as Fly secrets:
+
+```bash
+fly secrets set \
+  CLIENT_SECRETS_B64="$(base64 < client_secrets.json)" \
+  TOKEN_B64="$(base64 < token.json)"
+```
+
+The entrypoint shim decodes these to `/data/client_secrets.json` and
+`/data/token.json` on each machine start, but only if the files are not already
+present on the volume. After the first run the refreshed `token.json` lives on
+the volume and the env-var copy is ignored.
+
+### 5. Schedule the machine
+
+```bash
+fly machine run \
+  --schedule daily \
+  --volume data:/data \
+  ghcr.io/keif/yt-sub-playlist:<version>
+```
+
+Replace `<version>` with the image tag you want to pin (e.g. `v4.1.0`). See
+[releases](https://github.com/keif/yt-sub-playlist/releases) for available
+tags. Pinning to a specific version means you opt in to upgrades explicitly.
+
+> The image is published to `ghcr.io/keif/yt-sub-playlist` via issue #13. Until
+> that workflow is live, build and push the image manually or use a locally
+> pushed image reference.
+
+---
+
+## Verification
+
+**Confirm the scheduled machine registered:**
+
+```bash
+fly machine list
+```
+
+You should see one machine with state `stopped` and schedule `daily`.
+
+**Watch the first scheduled run:**
+
+```bash
+fly logs
+```
+
+A successful run ends with the playlist manager logging the number of videos
+added and then exiting 0. Look for a line like:
+
+```
+Sync complete. Added N videos to playlist.
+```
+
+**Confirm token persistence:**
+
+After the first run, inspect the volume to verify `token.json` was refreshed:
+
+```bash
+fly ssh console
+ls -la /data
+exit
+```
+
+A `token.json` modified after the run confirms the refresh round-trip worked.
+
+---
+
+## Re-authentication
+
+OAuth refresh tokens can expire after months of disuse or when your GCP
+project's OAuth policy changes. When the sync starts failing with `401
+Unauthorized` or `invalid_grant`, the refresh token has expired.
+
+Re-auth is the same local bootstrap flow repeated:
+
+1. On your laptop, re-run the OAuth flow:
+
+   ```bash
+   uv run python -m yt_sub_playlist.auth.oauth
+   ```
+
+   A browser window opens for you to re-authorize. This overwrites `token.json`
+   locally.
+
+2. Upload the new token:
+
+   ```bash
+   fly secrets set TOKEN_B64="$(base64 < token.json)"
+   ```
+
+3. The next scheduled run (or a manual `fly machine run`) will use the fresh
+   token. The entrypoint shim writes it to `/data/token.json` only if the file
+   does not exist, so you may need to remove the stale copy first:
+
+   ```bash
+   fly ssh console
+   rm /data/token.json
+   exit
+   ```
+
+   Then re-run step 2 or wait for the next scheduled machine start.

--- a/docs/deploy/fly.md
+++ b/docs/deploy/fly.md
@@ -60,18 +60,15 @@ before the scheduled job ever runs:
 fly machine run \
   --rm \
   --volume data:/data \
-  --entrypoint sh \
-  ghcr.io/keif/yt-sub-playlist:<version> \
-  -c 'chown -R 1000:1000 /data'
+  alpine sh -c 'chown -R 1000:1000 /data'
 ```
 
-The `--rm` flag deletes the chown machine after it exits. The scheduled
-machine in step 5 then attaches the same volume with the corrected ownership.
-
-(Alternatively, after a machine exists — for example after re-running step 5
-following a failed attempt — you can `fly ssh console` into it and run
-`chown -R 1000:1000 /data` interactively. The throwaway-machine flow above
-is preferred because it works from a clean state with no first-run failure.)
+`alpine` is used here rather than the project image because the project image
+sets `USER app` (UID 1000) at build time — an override like `--entrypoint sh`
+on the project image would still execute as the non-root user, and the chown
+would fail. The `--rm` flag deletes the helper machine once the chown
+completes. The scheduled machine in step 5 then attaches the same volume with
+the corrected ownership.
 
 ### 4. Upload secrets
 
@@ -175,12 +172,16 @@ Re-auth is the same local bootstrap flow repeated:
 
 3. The next scheduled run (or a manual `fly machine run`) will use the fresh
    token. The entrypoint shim writes it to `/data/token.json` only if the file
-   does not exist, so you may need to remove the stale copy first:
+   does not exist, so you need to remove the stale copy first. The scheduled
+   machine is stopped (`--restart no`), so `fly ssh console` won't work —
+   spin up a throwaway machine the same way you did for the chown step:
 
    ```bash
-   fly ssh console
-   rm /data/token.json
-   exit
+   fly machine run \
+     --rm \
+     --volume data:/data \
+     alpine sh -c 'rm -f /data/token.json'
    ```
 
-   Then re-run step 2 or wait for the next scheduled machine start.
+   Then wait for the next scheduled run, or kick one off manually with
+   `fly machine run --rm --volume data:/data ghcr.io/keif/yt-sub-playlist:<version>`.

--- a/docs/deploy/fly.md
+++ b/docs/deploy/fly.md
@@ -133,21 +133,13 @@ added and then exiting 0. Look for a line like:
 Processing complete: N/M videos added successfully
 ```
 
-**Confirm token persistence:**
-
-After the first run, inspect the volume to verify `token.json` was refreshed.
-The scheduled machine is stopped (`--restart no`), so use a throwaway alpine
-machine to look at the volume:
-
-```bash
-fly machine run \
-  --rm \
-  --volume data:/data \
-  alpine ls -la /data
-```
-
-A `token.json` with a mtime newer than when you uploaded it confirms the
-refresh round-trip worked.
+That log line is the verification. Fly volumes stay attached to the scheduled
+machine even while it is stopped, so a separate throwaway `fly machine run
+--volume data:/data ...` cannot mount `data` to inspect it — attempting so
+fails with "volume already attached." If the sync log shows successful video
+adds AND no `RefreshError` / 401 warnings, the token refresh round-trip
+worked. Actual inspection of `/data` requires destroying and recreating the
+scheduled machine (see the re-auth section for that pattern).
 
 ---
 
@@ -174,18 +166,31 @@ Re-auth is the same local bootstrap flow repeated:
    fly secrets set TOKEN_B64="$(base64 < token.json)"
    ```
 
-3. The next scheduled run (or a manual `fly machine run`) will use the fresh
-   token. The entrypoint shim writes it to `/data/token.json` only if the file
-   does not exist, so you need to remove the stale copy first. The scheduled
-   machine is stopped (`--restart no`), so `fly ssh console` won't work —
-   spin up a throwaway machine the same way you did for the chown step:
+3. Remove the stale token from the volume and rebuild the scheduled machine.
+   The entrypoint shim writes the env-var token to `/data/token.json` only if
+   the file does not exist, so the old token has to go first. Fly attaches
+   the volume exclusively to the scheduled machine (even when stopped), so
+   you have to destroy that machine before a throwaway can mount the volume:
 
    ```bash
+   # Find the scheduled machine's ID:
+   fly machine list
+
+   # Destroy it. The volume detaches automatically.
+   fly machine destroy <machine-id>
+
+   # Use a throwaway alpine to remove the stale token file.
    fly machine run \
      --rm \
      --volume data:/data \
      alpine sh -c 'rm -f /data/token.json'
-   ```
 
-   Then wait for the next scheduled run, or kick one off manually with
-   `fly machine run --rm --volume data:/data ghcr.io/keif/yt-sub-playlist:<version>`.
+   # Recreate the scheduled machine (same command as step 5). The entrypoint
+   # will hydrate the new TOKEN_B64 secret into /data/token.json on next
+   # scheduled start.
+   fly machine run \
+     --schedule daily \
+     --restart no \
+     --volume data:/data \
+     ghcr.io/keif/yt-sub-playlist:<version>
+   ```

--- a/fly.toml.example
+++ b/fly.toml.example
@@ -1,0 +1,28 @@
+# fly.toml.example — app-level config for yt-sub-playlist on Fly.io.
+#
+# Copy to fly.toml before running `fly launch --copy-config --no-deploy`.
+# The schedule, image pin, and volume attachment live on the machine itself
+# (set via `fly machine run`), not here. Do NOT run `fly deploy` — that
+# creates a separate always-on machine you will be billed for.
+#
+# See docs/deploy/fly.md for the full runbook.
+
+app = "yt-sub-playlist-yourname"   # replace with your chosen app name
+primary_region = "iad"             # nearest Fly region; see `fly platform regions`
+
+[build]
+  # Image is pinned at deploy time via `fly machine run --image ...`.
+  # This stanza is here so Fly doesn't prompt you to set a builder during
+  # `fly launch`. Override with your preferred region or build approach.
+
+[[mounts]]
+  source = "data"
+  destination = "/data"
+  # Volume holds client_secrets.json and token.json between runs.
+  # Initial creation: `fly volume create data --size 1`
+  # After creation, run the one-time chown so UID 1000 can write:
+  #   fly ssh console -C "chown 1000:1000 /data"
+
+[vm]
+  size = "shared-cpu-1x"
+  memory = "256mb"

--- a/fly.toml.example
+++ b/fly.toml.example
@@ -20,8 +20,10 @@ primary_region = "iad"             # nearest Fly region; see `fly platform regio
   destination = "/data"
   # Volume holds client_secrets.json and token.json between runs.
   # Initial creation: `fly volume create data --size 1`
-  # After creation, run the one-time chown so UID 1000 can write:
-  #   fly ssh console -C "chown 1000:1000 /data"
+  # After creation, run the one-time chown so UID 1000 can write. Use a
+  # throwaway alpine machine — fly ssh console doesn't work yet because no
+  # scheduled machine exists:
+  #   fly machine run --rm --volume data:/data alpine sh -c 'chown -R 1000:1000 /data'
 
 [vm]
   size = "shared-cpu-1x"


### PR DESCRIPTION
Closes #14.

## Summary

Adds `docs/deploy/fly.md` (runbook) and `fly.toml.example` (app-level config template) for the Fly.io deploy target.

## Decisions worth flagging

- **No `fly deploy`.** The runbook explicitly warns against it — a scheduled machine is the entire compute footprint; `fly deploy` creates a separate always-on machine users would be billed for.
- **Chown helper uses `alpine`, not the project image.** The project image bakes in `USER app` at build time, and `--entrypoint sh` on `fly machine run` does NOT override the USER directive. Attempting to chown from the project image would run as UID 1000 — the very user we're granting permissions to — and fail. `alpine` sidesteps this cleanly.
- **`--restart no` on the scheduled machine.** Without it, Fly defaults to `on-failure` restart, so an expired refresh token would put the machine into a tight retry loop until quota exhaustion.
- **Verification is log-based.** Fly volumes attach exclusively to a machine, even when stopped — so a throwaway helper can't mount `/data` to inspect the volume while the scheduled machine holds it. If `fly logs` shows successful video adds without `RefreshError` / 401, the refresh worked.
- **Re-auth destroys + recreates the scheduled machine.** Same volume-attachment reason. The alpine-helper `rm` for the stale token can only run after the scheduled machine is destroyed.

## Codex review history

| Pass | Findings | Fixed in |
|---|---|---|
| 1 | P1 fresh-deploy chown ordering; P2 default restart policy | `c3606d3` |
| 2 | P1 `--entrypoint sh` doesn't override USER; P2 stale `fly ssh` in `fly.toml.example`; P2 `fly ssh` for stopped machine in re-auth | `7e23749` |
| 3 | P2 broken oauth-bootstrap link (accepted — resolves at #17 merge); P2 verification uses `fly ssh` on stopped machine; P3 wrong CLI log line | `3712ac5` |
| 4 | P2 exclusive volume attachment breaks throwaway-mount pattern | `f4275e0` |
| 5 | Clean — no findings | merge |

## Cross-PR dependency

The runbook links to `docs/deploy/oauth-bootstrap.md`, which is being added in a sibling PR (#17 half). The link will resolve when both merge; if the PRs land out of order, one will briefly have a broken link. Not gating on this.

## Test plan (downstream)

- [ ] After #13 publishes the first image, walk the runbook end-to-end on a real Fly account: verify chown → secrets → scheduled machine → observe a real cron trigger → confirm token refresh
- [ ] Re-auth flow tested against an intentionally-expired token