### PR TITLE
docs(deploy): add raw Docker / VPS runbook

### DIFF
--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -25,7 +25,7 @@ That process produces `client_secrets.json` and `token.json`. You will copy both
 
 ### Directory layout
 
-All credentials and runtime state live in `./data/`. The compose file mounts it as `./data:/data`. The container writes the refreshed `token.json` back to this directory on every run, so it must be writable by the container's UID.
+All credentials and runtime state live in `./data/`. The compose file mounts it as `./data:/data`. The container writes state files (playlist cache, API log) here on every run, and rewrites `token.json` whenever the OAuth library refreshes it, so this directory must be writable by the container's UID.
 
 ```
 /srv/yt-sub-playlist/
@@ -120,7 +120,7 @@ Once #13 ships, swap the compose file's `build: .` for an image pin and pull ins
    ```yaml
    services:
      sync:
-       image: ghcr.io/keif/playlist-from-subs:<version>
+       image: ghcr.io/keif/yt-sub-playlist:<version>
    ```
 2. Pull the published image:
    ```bash

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -281,8 +281,7 @@ Google refresh tokens can expire after roughly **6 months of disuse** or if the 
    ssh user@your-server 'sudo install -m 600 -o 1000 -g 1000 /tmp/token.json /srv/yt-sub-playlist/data/token.json && rm /tmp/token.json'
 
    # Option B: rsync with --rsync-path=sudo (requires passwordless sudo)
-   rsync -av --rsync-path='sudo rsync' /path/to/token.json user@your-server:/srv/yt-sub-playlist/data/
-   sudo chown 1000:1000 /srv/yt-sub-playlist/data/token.json   # over ssh
+   rsync -av --rsync-path='sudo rsync' --chown=1000:1000 /path/to/token.json user@your-server:/srv/yt-sub-playlist/data/
 
    # macOS Docker Desktop / OrbStack hosts (no UID lockdown): plain scp works.
    scp /path/to/token.json user@your-server:/srv/yt-sub-playlist/data/

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -1,0 +1,260 @@
+# Raw Docker / VPS Runbook
+
+Self-host `yt-sub-playlist` on any Linux VPS (or local machine) with Docker installed. The sync job runs as a one-shot container triggered by host cron or a systemd timer. No daemon, no restart policy.
+
+---
+
+## Prerequisites
+
+- **Docker 24+** (ships Compose v2 as `docker compose`). Check: `docker compose version`.
+- `make` — optional shortcut layer; not required.
+- A checkout of this repo on the server (or at least `docker-compose.yml` and `Dockerfile`):
+  ```bash
+  git clone https://github.com/keif/yt-sub-playlist.git /srv/yt-sub-playlist
+  cd /srv/yt-sub-playlist
+  ```
+
+**OAuth credentials** — complete the one-time bootstrap on your laptop first:  
+→ [docs/deploy/oauth-bootstrap.md](./oauth-bootstrap.md)
+
+That process produces `client_secrets.json` and `token.json`. You will copy both to the server in the Setup section below.
+
+---
+
+## Setup
+
+### Directory layout
+
+All credentials and runtime state live in `./data/`. The compose file mounts it as `./data:/data`. The container writes the refreshed `token.json` back to this directory on every run, so it must be writable by the container's UID.
+
+```
+/srv/yt-sub-playlist/
+├── docker-compose.yml
+├── Dockerfile
+└── data/                  ← bind-mounted at /data inside the container
+    ├── client_secrets.json
+    ├── token.json
+    ├── config.json        (optional)
+    ├── .env               (optional)
+    └── ...                (runtime: processed_videos.json, playlist_cache/, api_call_log.json)
+```
+
+### Create and lock down the data directory
+
+```bash
+mkdir -p ./data
+
+# Linux hosts: the container runs as UID 1000. Give that UID write access.
+# macOS Docker Desktop / OrbStack: UID translation is handled automatically —
+# you can skip the chown step, but it won't hurt to run it.
+sudo chown -R 1000:1000 ./data
+
+# Restrict access — this directory holds a live OAuth refresh token.
+chmod 700 ./data
+```
+
+### Drop credentials into ./data/
+
+```bash
+# From your laptop (adjust paths):
+scp /path/to/client_secrets.json user@your-server:/srv/yt-sub-playlist/data/
+scp /path/to/token.json          user@your-server:/srv/yt-sub-playlist/data/
+```
+
+### Optional: app configuration
+
+The entrypoint forces the container's working directory to `/data`, so the app reads `config.json` and `.env` from that directory automatically. Drop them in if you want to override defaults (playlist name, duration filters, lookback window, etc.):
+
+```bash
+scp /path/to/config.json user@your-server:/srv/yt-sub-playlist/data/   # optional
+scp /path/to/.env        user@your-server:/srv/yt-sub-playlist/data/   # optional
+```
+
+See the [README](../../README.md) for the full list of supported env vars and config keys.
+
+---
+
+## Build vs. pull
+
+### Now: build locally
+
+Image publishing to `ghcr.io` is in-flight (#13). Until it lands, build the image from source:
+
+```bash
+docker compose build
+```
+
+### Later: pull from ghcr.io
+
+Once #13 ships, swap the compose file's `build: .` for an image pin and pull instead of building:
+
+1. In `docker-compose.yml`, replace:
+   ```yaml
+   services:
+     sync:
+       build: .
+       image: yt-sub-playlist:local
+   ```
+   with:
+   ```yaml
+   services:
+     sync:
+       image: ghcr.io/keif/yt-sub-playlist:<version>
+   ```
+2. Pull the published image:
+   ```bash
+   docker compose pull
+   ```
+
+Pin to a specific version tag rather than `:latest` so you opt in to upgrades explicitly.
+
+---
+
+## Verification: first run
+
+Do a dry run before scheduling anything:
+
+```bash
+docker compose run --rm sync --dry-run
+```
+
+Expected: the sync logic runs, no videos are added to the playlist, no errors. If you see `ModuleNotFoundError` or a credentials failure, check that both JSON files landed in `./data/` with correct permissions.
+
+---
+
+## Scheduling
+
+The `sync` service is intentionally one-shot — no `restart` policy. Pick whichever scheduler fits your server.
+
+### Option A: host cron
+
+```bash
+crontab -e
+```
+
+Add a line (runs daily at 06:00):
+
+```cron
+0 6 * * *  cd /srv/yt-sub-playlist && /usr/bin/docker compose run --rm sync >> /var/log/yt-sub-playlist.log 2>&1
+```
+
+Use the full path to `docker` (`which docker`) if your cron environment doesn't include it.
+
+### Option B: systemd timer
+
+Create two unit files. Replace `/srv/yt-sub-playlist` with your actual checkout path.
+
+**/etc/systemd/system/yt-sub-playlist-sync.service**
+
+```ini
+[Unit]
+Description=yt-sub-playlist sync
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/srv/yt-sub-playlist
+ExecStart=/usr/bin/docker compose run --rm sync
+StandardOutput=journal
+StandardError=journal
+```
+
+**/etc/systemd/system/yt-sub-playlist-sync.timer**
+
+```ini
+[Unit]
+Description=Run yt-sub-playlist sync daily at 06:00
+
+[Timer]
+OnCalendar=*-*-* 06:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now yt-sub-playlist-sync.timer
+
+# Verify the timer is active:
+systemctl list-timers yt-sub-playlist-sync.timer
+
+# Trigger a manual run immediately (bypasses the timer schedule):
+sudo systemctl start yt-sub-playlist-sync.service
+```
+
+**Note:** cron *inside* the container is out of scope. The container exits after each sync; scheduling is the host's job.
+
+---
+
+## Logs
+
+- **Host cron path:** logs land in whatever file you redirect to (the example above uses `/var/log/yt-sub-playlist.log`). Rotate with `logrotate` if needed.
+- **systemd timer path:** logs go to the journal. Read them with:
+  ```bash
+  journalctl -u yt-sub-playlist-sync.service
+  journalctl -u yt-sub-playlist-sync.service --since "1 hour ago"
+  ```
+
+After a real run (not `--dry-run`), confirm the token was refreshed:
+
+```bash
+# The mtime should reflect the most recent run:
+ls -la ./data/token.json
+```
+
+If the mtime updates, the OAuth refresh cycle is working and the token will continue to be renewed on each run.
+
+---
+
+## Dashboard
+
+The dashboard is **out of scope for v1** on raw Docker. It is intentionally commented out of `docker-compose.yml`.
+
+Recommended pattern for accessing server state locally:
+
+1. Mount the server's `./data/` directory to your laptop via **sshfs** or **Tailscale**:
+   ```bash
+   sshfs user@your-server:/srv/yt-sub-playlist/data /mnt/yt-data
+   ```
+2. Run the dashboard locally, pointed at the mounted directory:
+   ```bash
+   cd dashboard/backend
+   YT_SUB_PLAYLIST_DATA_DIR=/mnt/yt-data uv run python app.py
+   # Open http://localhost:5001
+   ```
+
+A future spec will cover dashboard deploy with a proper auth layer.
+
+---
+
+## Re-authentication
+
+Google refresh tokens can expire after roughly **6 months of disuse** or if the OAuth client's policy changes. When the sync starts failing with a `401` / `invalid_grant` error, you need to re-run the OAuth bootstrap.
+
+1. On your laptop, re-run the bootstrap to produce a fresh `token.json`:
+   ```bash
+   uv run python -m yt_sub_playlist.auth.oauth
+   ```
+   See [docs/deploy/oauth-bootstrap.md](./oauth-bootstrap.md) for the full flow.
+
+2. Copy the new token to the server:
+   ```bash
+   scp /path/to/token.json user@your-server:/srv/yt-sub-playlist/data/
+   ```
+   Or using rsync:
+   ```bash
+   rsync -av /path/to/token.json user@your-server:/srv/yt-sub-playlist/data/
+   ```
+
+3. If a sync container is currently running, stop it:
+   ```bash
+   docker stop yt-sub-playlist-sync
+   ```
+   The next scheduled run will pick up the new token automatically.
+
+Re-auth is also required if you rotate your GCP OAuth client credentials — in that case replace both `client_secrets.json` and `token.json`.

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -10,7 +10,7 @@ Self-host `yt-sub-playlist` on any Linux VPS (or local machine) with Docker inst
 - `make` — optional shortcut layer; not required.
 - A **full checkout** of this repo on the server. The Dockerfile builds from the whole tree (`pyproject.toml`, `uv.lock`, `LICENSE`, `README.md`, `yt_sub_playlist/`), so grabbing just `docker-compose.yml` and `Dockerfile` will fail at build time. Once the published image ships (issue #13), you can skip this and pull instead — see [Build vs. pull](#build-vs-pull) below.
   ```bash
-  git clone https://github.com/keif/yt-sub-playlist.git /srv/yt-sub-playlist
+  git clone https://github.com/keif/playlist-from-subs.git /srv/yt-sub-playlist
   cd /srv/yt-sub-playlist
   ```
 
@@ -77,7 +77,14 @@ sudo chmod 700 ./data
 
 ### Optional: app configuration
 
-The entrypoint forces the container's working directory to `/data`, so the app reads `config.json` and `.env` from that directory automatically. Drop them in if you want to override defaults (playlist name, duration filters, lookback window, etc.):
+The entrypoint forces the container's working directory to `/data`, so the
+app reads `config.json` and `.env` from that directory automatically. Drop
+them in if you want to override defaults (playlist name, duration filters,
+lookback window, etc.). **Do this BEFORE the "Lock down the data directory"
+step above** — otherwise the same `chown 1000:1000` + `chmod 700` will lock
+the host user out of writing into `./data/`. If you missed it, either
+`sudo cp` the files as root or temporarily chown back to your user, drop
+them in, then re-run the lockdown.
 
 ```bash
 scp /path/to/config.json user@your-server:/srv/yt-sub-playlist/data/   # optional
@@ -113,7 +120,7 @@ Once #13 ships, swap the compose file's `build: .` for an image pin and pull ins
    ```yaml
    services:
      sync:
-       image: ghcr.io/keif/yt-sub-playlist:<version>
+       image: ghcr.io/keif/playlist-from-subs:<version>
    ```
 2. Pull the published image:
    ```bash
@@ -211,21 +218,27 @@ sudo systemctl start yt-sub-playlist-sync.service
 
 ## Logs
 
-- **Host cron path:** logs land in whatever file you redirect to (the example above uses `/var/log/yt-sub-playlist.log`). Rotate with `logrotate` if needed.
+- **Host cron path:** logs land in whatever file you redirect to (the example above uses `${HOME}/yt-sub-playlist.log`, or `/var/log/yt-sub-playlist.log` for the root-cron variant). Rotate with `logrotate` if needed.
 - **systemd timer path:** logs go to the journal. Read them with:
   ```bash
   journalctl -u yt-sub-playlist-sync.service
   journalctl -u yt-sub-playlist-sync.service --since "1 hour ago"
   ```
 
-After a real run (not `--dry-run`), confirm the token was refreshed:
+After a real run (not `--dry-run`), the primary verification is the log
+output — look for `Processing complete: N/M videos added successfully`
+and no `RefreshError` / `401` warnings.
+
+Token file mtime is a WEAKER signal: the app only rewrites `token.json`
+when the credentials it loaded were expired or otherwise invalid. On a
+successful run with a still-valid access token the file is untouched, so
+an unchanged mtime does NOT mean the refresh cycle is broken. The mtime
+only proves activity when it DOES advance — an updated mtime means a
+refresh happened and the round-trip works.
 
 ```bash
-# The mtime should reflect the most recent run:
 ls -la ./data/token.json
 ```
-
-If the mtime updates, the OAuth refresh cycle is working and the token will continue to be renewed on each run.
 
 ---
 

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -270,13 +270,22 @@ Google refresh tokens can expire after roughly **6 months of disuse** or if the 
    ```
    See [docs/deploy/oauth-bootstrap.md](./oauth-bootstrap.md) for the full flow.
 
-2. Copy the new token to the server:
+2. Copy the new token to the server. `./data/` is chmod 700 owned by UID
+   1000 after the initial lockdown, so a plain `scp` as the deploy user
+   will fail on Linux hosts where the deploy user is not UID 1000. Use
+   one of these patterns:
+
    ```bash
+   # Option A: scp to a staging path, then move as root
+   scp /path/to/token.json user@your-server:/tmp/token.json
+   ssh user@your-server 'sudo install -m 600 -o 1000 -g 1000 /tmp/token.json /srv/yt-sub-playlist/data/token.json && rm /tmp/token.json'
+
+   # Option B: rsync with --rsync-path=sudo (requires passwordless sudo)
+   rsync -av --rsync-path='sudo rsync' /path/to/token.json user@your-server:/srv/yt-sub-playlist/data/
+   sudo chown 1000:1000 /srv/yt-sub-playlist/data/token.json   # over ssh
+
+   # macOS Docker Desktop / OrbStack hosts (no UID lockdown): plain scp works.
    scp /path/to/token.json user@your-server:/srv/yt-sub-playlist/data/
-   ```
-   Or using rsync:
-   ```bash
-   rsync -av /path/to/token.json user@your-server:/srv/yt-sub-playlist/data/
    ```
 
 3. If a sync container is currently running, stop it:

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -141,6 +141,14 @@ docker compose run --rm sync --dry-run
 
 Expected: the sync logic runs, no videos are added to the playlist, no errors. If you see `ModuleNotFoundError` or a credentials failure, check that both JSON files landed in `./data/` with correct permissions.
 
+> **--dry-run is not fully no-mutation on first run.** If `PLAYLIST_ID` is
+> not set in `config.json` or `.env`, the CLI creates a new empty playlist
+> on YouTube before entering dry-run mode (that's the "or create" side of
+> `get_or_create_playlist`). Set `PLAYLIST_ID` in your `./data/.env`
+> before the first `--dry-run` if you want strictly no-mutation verification.
+> Follow-up code work will move this side effect behind the `--dry-run`
+> gate.
+
 ---
 
 ## Scheduling
@@ -237,7 +245,8 @@ only proves activity when it DOES advance — an updated mtime means a
 refresh happened and the round-trip works.
 
 ```bash
-ls -la ./data/token.json
+# Linux with the lockdown applied: sudo, because ./data is chmod 700 owned by 1000
+sudo ls -la ./data/token.json
 ```
 
 ---

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -8,7 +8,7 @@ Self-host `yt-sub-playlist` on any Linux VPS (or local machine) with Docker inst
 
 - **Docker 24+** (ships Compose v2 as `docker compose`). Check: `docker compose version`.
 - `make` — optional shortcut layer; not required.
-- A checkout of this repo on the server (or at least `docker-compose.yml` and `Dockerfile`):
+- A **full checkout** of this repo on the server. The Dockerfile builds from the whole tree (`pyproject.toml`, `uv.lock`, `LICENSE`, `README.md`, `yt_sub_playlist/`), so grabbing just `docker-compose.yml` and `Dockerfile` will fail at build time. Once the published image ships (issue #13), you can skip this and pull instead — see [Build vs. pull](#build-vs-pull) below.
   ```bash
   git clone https://github.com/keif/yt-sub-playlist.git /srv/yt-sub-playlist
   cd /srv/yt-sub-playlist
@@ -31,34 +31,48 @@ All credentials and runtime state live in `./data/`. The compose file mounts it 
 /srv/yt-sub-playlist/
 ├── docker-compose.yml
 ├── Dockerfile
-└── data/                  ← bind-mounted at /data inside the container
-    ├── client_secrets.json
-    ├── token.json
-    ├── config.json        (optional)
-    ├── .env               (optional)
-    └── ...                (runtime: processed_videos.json, playlist_cache/, api_call_log.json)
+└── data/                             ← bind-mounted at /data inside the container
+    ├── client_secrets.json           (credentials, you provide)
+    ├── token.json                    (credentials, you provide; refreshed in place)
+    ├── config.json                   (optional)
+    ├── .env                          (optional)
+    └── yt_sub_playlist/data/         (runtime state — see note below)
+        ├── processed_videos.json
+        ├── playlist_cache/
+        └── api_call_log.json
 ```
 
-### Create and lock down the data directory
+> **Note about the buried runtime state.** The CLI's default `data_dir` is
+> `"yt_sub_playlist/data"` (a relative path baked in for local-dev use). The
+> container's entrypoint cd's to `/data`, so runtime state actually lands
+> under `./data/yt_sub_playlist/data/` on the host, not directly next to
+> `token.json`. Look there when backing up or inspecting the cache. A
+> follow-up issue will unify this via a `YT_SUB_PLAYLIST_DATA_DIR` env var
+> so the container can write state directly under `/data`.
+
+### Drop credentials into ./data/
+
+Copy credentials AS THE HOST USER first — otherwise the chown+chmod steps
+below lock the current user out of writing into `./data/`.
 
 ```bash
 mkdir -p ./data
 
+# From your laptop:
+scp /path/to/client_secrets.json user@your-server:/srv/yt-sub-playlist/data/
+scp /path/to/token.json          user@your-server:/srv/yt-sub-playlist/data/
+```
+
+### Lock down the data directory
+
+```bash
 # Linux hosts: the container runs as UID 1000. Give that UID write access.
 # macOS Docker Desktop / OrbStack: UID translation is handled automatically —
-# you can skip the chown step, but it won't hurt to run it.
+# skip these two commands on macOS.
 sudo chown -R 1000:1000 ./data
 
 # Restrict access — this directory holds a live OAuth refresh token.
-chmod 700 ./data
-```
-
-### Drop credentials into ./data/
-
-```bash
-# From your laptop (adjust paths):
-scp /path/to/client_secrets.json user@your-server:/srv/yt-sub-playlist/data/
-scp /path/to/token.json          user@your-server:/srv/yt-sub-playlist/data/
+sudo chmod 700 ./data
 ```
 
 ### Optional: app configuration
@@ -135,8 +149,12 @@ crontab -e
 Add a line (runs daily at 06:00):
 
 ```cron
-0 6 * * *  cd /srv/yt-sub-playlist && /usr/bin/docker compose run --rm sync >> /var/log/yt-sub-playlist.log 2>&1
+0 6 * * *  cd /srv/yt-sub-playlist && /usr/bin/docker compose run --rm sync >> ${HOME}/yt-sub-playlist.log 2>&1
 ```
+
+Log to a user-writable path (`${HOME}/yt-sub-playlist.log`) rather than
+`/var/log/`, which requires root. If you install the cron entry as root
+(via `sudo crontab -e`) then `/var/log/yt-sub-playlist.log` is fine.
 
 Use the full path to `docker` (`which docker`) if your cron environment doesn't include it.
 
@@ -213,22 +231,19 @@ If the mtime updates, the OAuth refresh cycle is working and the token will cont
 
 ## Dashboard
 
-The dashboard is **out of scope for v1** on raw Docker. It is intentionally commented out of `docker-compose.yml`.
+The dashboard is **out of scope for v1** on raw Docker. It is intentionally
+commented out of `docker-compose.yml`. The dashboard backend's data-source
+path is currently hard-coded to a local checkout — the same buried
+`yt_sub_playlist/data/` mentioned in the Directory layout note — and does
+not read a data-dir override env var, so simply mounting the server's
+`./data/` locally is not enough to point the dashboard at it.
 
-Recommended pattern for accessing server state locally:
+For now, treat "look at the server's state" as an admin-shell task:
+`ssh user@your-server 'ls -la /srv/yt-sub-playlist/data/yt_sub_playlist/data/'`.
 
-1. Mount the server's `./data/` directory to your laptop via **sshfs** or **Tailscale**:
-   ```bash
-   sshfs user@your-server:/srv/yt-sub-playlist/data /mnt/yt-data
-   ```
-2. Run the dashboard locally, pointed at the mounted directory:
-   ```bash
-   cd dashboard/backend
-   YT_SUB_PLAYLIST_DATA_DIR=/mnt/yt-data uv run python app.py
-   # Open http://localhost:5001
-   ```
-
-A future spec will cover dashboard deploy with a proper auth layer.
+A future spec will cover dashboard deploy (with a proper auth layer) and,
+alongside it, a data-dir env var that lets the dashboard point at a mounted
+or remote directory.
 
 ---
 


### PR DESCRIPTION
Closes #16.

## Summary

Adds `docs/deploy/docker.md` — the lowest-common-denominator "I have a VPS, install Docker, drop this on" runbook. Covers prereqs, OAuth bootstrap link, directory layout, build-now vs pull-later, scheduling (host cron + systemd timer), verification, dashboard-out-of-scope, and re-auth.

## Decisions worth flagging

- **Full checkout required (for now).** The Dockerfile builds from the whole tree, so users can't grab just compose+Dockerfile. Once #13 publishes the image, the runbook shows the `image:` swap so subsequent users can skip the checkout.
- **Data ends up buried at `./data/yt_sub_playlist/data/`.** `PlaylistManager` defaults its `data_dir` to `"yt_sub_playlist/data"` as a relative path; the entrypoint cd's to `/data`, so the actual state files land in that nested subdir on the host. Documented honestly with a follow-up-issue note.
- **`--dry-run` is not strictly no-mutation.** If `PLAYLIST_ID` is unset, `get_or_create_playlist()` creates a new playlist on YouTube BEFORE the dry-run branch. Callout added. Follow-up code work should move that create step behind the `--dry-run` gate.
- **Two scheduling patterns documented equally.** Host cron (with a user-writable log path — `${HOME}/…` by default, `/var/log/` only when installed via root's crontab) and systemd timer.
- **UID 1000 lockdown means `sudo` for post-lockdown inspection.** Documented.

## Codex review history

| Pass | Findings | Fixed in |
|---|---|---|
| 1 | 5 P2s: full-checkout requirement, buried data path, chown/copy ordering, cron log path, dashboard env var doesn't exist | `089823d` |
| 2 | P2 wrong clone URL, P2 pull image name inconsistent, P3 token-rewrite phrasing, P3 config-copy ordering, P3 log-path consistency, P3 token mtime | `704a564` + `ced6e57` |
| 3-4 | P2 image name; P3 mtime warning | `ced6e57` + `c9b4688` |
| 5 | P2 re-auth ownership stays on remote | `7a9fc14` |
| 6 | P2 --dry-run not fully no-mutation; P3 sudo for inspection | `6165ed9` |

Broken `oauth-bootstrap.md` link deferred — resolves at #17 merge.

## Follow-up issues worth filing after merge

1. **Move the `get_or_create_playlist` create step behind `--dry-run`.** True dry-runs should never mutate.
2. **Add a `YT_SUB_PLAYLIST_DATA_DIR` env var** so the container can write state directly under `/data` instead of `/data/yt_sub_playlist/data/`. Same env var could unblock the dashboard-against-mounted-server pattern.

## Test plan (downstream)

- [ ] After #13 publishes an image, walk the runbook end-to-end on a real Linux VPS as a non-UID-1000 user (the case with the most sharp edges)
- [ ] Run through both scheduling paths (host cron + systemd timer)
- [ ] Trigger a re-auth against an intentionally-expired token, walk the Option A / Option B copy patterns