### PR TITLE
docs(deploy): add OAuth bootstrap guide

### DIFF
--- a/docs/deploy/oauth-bootstrap.md
+++ b/docs/deploy/oauth-bootstrap.md
@@ -1,0 +1,130 @@
+# OAuth Bootstrap
+
+One-time setup required before any deploy path. You'll end up with two files:
+
+- `client_secrets.json` — your GCP OAuth client credentials
+- `token.json` — a serialized credential object with access + refresh tokens
+
+Both files go to your deploy target. How they get there (env vars, bind mounts, fly secrets) is covered in the target-specific runbooks. This doc covers getting them.
+
+---
+
+## 1. Create a Google Cloud project
+
+Visit [https://console.cloud.google.com](https://console.cloud.google.com).
+
+Top nav → project picker → **New Project**. Name it whatever — `yt-sub-playlist` works. Note the project ID; you'll need it if you ever want to manage quota via the CLI.
+
+---
+
+## 2. Enable YouTube Data API v3
+
+With your project selected:
+
+**APIs & Services → Library → search "YouTube Data API v3" → Enable.**
+
+---
+
+## 3. Configure the OAuth consent screen
+
+**APIs & Services → OAuth consent screen.**
+
+- **User type: External.** Choose this even for personal use. "Internal" requires a Google Workspace organization. External with Testing status is the right choice for self-hosted deployments.
+- Fill in the required fields (app name, support email). The values don't matter — this screen is only shown to you.
+- **Scopes:** skip for now — the app requests scopes at runtime.
+- **Test users:** add your own Google account email. This is the account you'll authorize in step 5.
+
+**Publishing status: leave it as Testing.** Testing mode caps the app at 100 authorized users and skips Google's OAuth verification process entirely — no review queue, no branding review, no wait. Since you're the only user (you are the test user you just added), this is the correct configuration. Do not click "Publish" — that triggers the verification process and offers nothing in return for a personal deployment.
+
+---
+
+## 4. Create an OAuth 2.0 client
+
+**APIs & Services → Credentials → Create Credentials → OAuth client ID.**
+
+- **Application type: Desktop app.** Not "Web application" — the local browser flow used by the bootstrap script requires Desktop type.
+- Name it anything.
+
+After creation, click **Download JSON**. Rename the downloaded file to `client_secrets.json`.
+
+---
+
+## 5. Run the local bootstrap
+
+You need the repo on your laptop and `uv` installed ([https://docs.astral.sh/uv/](https://docs.astral.sh/uv/)).
+
+```bash
+git clone https://github.com/keif/yt-sub-playlist.git
+cd yt-sub-playlist
+uv sync
+```
+
+Place `client_secrets.json` at the repo root (the same directory as `pyproject.toml`):
+
+```bash
+mv ~/Downloads/client_secrets.json .
+```
+
+Run the auth bootstrap:
+
+```bash
+uv run python -m yt_sub_playlist.auth.oauth
+```
+
+A browser window opens to Google's consent screen. Sign in with the test user account you added in step 3. Grant the requested YouTube permissions. The browser will show a "The authentication flow has completed" page — you can close it.
+
+Back in the terminal you'll see:
+
+```
+Authentication successful for channel: <your channel name>
+```
+
+A `token.json` file is now written to the repo root.
+
+---
+
+## 6. What you have
+
+Two files at the repo root:
+
+```
+client_secrets.json   ← OAuth client ID + secret (from GCP)
+token.json            ← serialized access + refresh token (from step 5)
+```
+
+**Do not commit either file.** Both are in `.gitignore`. The deploy runbooks walk you through uploading them to your chosen target.
+
+---
+
+## 7. Encoding for env-var targets
+
+Fly.io and GitHub Actions store these as secrets via environment variables. `token.json` despite its `.json` extension is a binary credentials serialization — raw env-var transit corrupts it on binary content. Both files are base64-encoded by convention so the contract is consistent.
+
+When a runbook tells you to set a secret, use:
+
+```bash
+base64 < client_secrets.json
+base64 < token.json
+```
+
+The deploy target's entrypoint shim decodes them back to disk before the app starts.
+
+> Raw Docker / VPS: you copy the files directly into the bind-mounted data directory — no base64 needed. See `docs/deploy/docker.md`.
+
+---
+
+## 8. Re-auth when tokens expire
+
+Google revokes refresh tokens after approximately 6 months of inactivity, or when the OAuth client configuration changes. When this happens, syncs start failing with `RefreshError` or HTTP 401.
+
+To recover:
+
+1. On your laptop, in the repo clone from step 5:
+   ```bash
+   rm token.json
+   uv run python -m yt_sub_playlist.auth.oauth
+   ```
+2. Complete the consent flow again (same browser step as above).
+3. Re-upload the new `token.json` to your deploy target per that target's runbook (re-encode with `base64 < token.json` first if the target uses env-var secrets).
+
+The re-auth process is identical to the initial bootstrap. No GCP changes needed — the OAuth client and consent screen configuration persist.

--- a/docs/deploy/oauth-bootstrap.md
+++ b/docs/deploy/oauth-bootstrap.md
@@ -29,36 +29,36 @@ With your project selected:
 
 **APIs & Services → OAuth consent screen.**
 
-- **User type: External.** Choose this even for personal use. "Internal" requires a Google Workspace organization. External with Testing status is the right choice for self-hosted deployments.
+- **User type: External.** Choose this even for personal use. "Internal" requires a Google Workspace organization.
 - Fill in the required fields (app name, support email). The values don't matter — this screen is only shown to you.
 - **Scopes:** skip for now — the app requests scopes at runtime.
 - **Test users:** add your own Google account email. This is the account you'll authorize in step 5.
 
-**Publishing status: leave it as Testing.** Testing mode caps the app at 100
-authorized users and skips Google's OAuth verification process entirely — no
-review queue, no branding review, no wait.
+### Publishing status: choose Production (recommended) or Testing
 
-> ⚠️ **Testing-mode refresh tokens expire in 7 days.** For OAuth apps in
-> Testing status that request sensitive scopes (which `youtube` is), Google
-> caps refresh-token lifetime at 7 days regardless of activity. Your
-> `token.json` will start failing with `RefreshError` / 401 roughly a week
-> after each bootstrap. For personal deploy-your-own use this means you
-> need to re-run this bootstrap and re-upload `token.json` once a week.
->
-> Options if that's untenable:
-> 1. **Publish the app to Production status.** Refresh tokens then last
->    until revoked (typically ~6 months of inactivity). For unverified
->    apps requesting sensitive scopes, Google shows users a "This app isn't
->    verified" warning during consent — you can click through it since you
->    are the developer. Sensitive-scope verification (removing the warning)
->    is a Google review process not worth pursuing for personal use.
-> 2. **Automate the weekly re-auth.** Not covered by this project today;
->    would need a monitoring hook + a scripted re-auth flow.
->
-> Publishing to Production without verification is the pragmatic default
-> for one-user deploy-your-own. Do that via OAuth consent screen → **Publish
-> app**. The warning during your own consent is a one-time click. Google
-> may email periodically about verification; you can ignore it for personal use.
+Google issues **different refresh-token lifetimes** for the two modes when
+your app requests sensitive scopes (which the `youtube` scope is):
+
+- **Testing status:** refresh tokens **expire in 7 days**. You will need to
+  re-run this bootstrap and re-upload `token.json` every week. Fine if you
+  are experimenting; painful for actual daily-cron use.
+- **Production status (unverified):** refresh tokens last until revoked
+  (typically ~6 months of inactivity). Google shows a "This app isn't
+  verified" warning during consent — click "Advanced → Go to (app name)
+  (unsafe)" once, and it never appears again for that account. Sensitive-
+  scope verification (which removes the warning entirely) is a Google
+  review process not worth pursuing for personal use.
+
+**For deploy-your-own recommend: Production, unverified.** Do that by
+clicking **Publish app** on the OAuth consent screen. This is the same as
+what most personal automations that use Google APIs settle on. Google may
+occasionally email about verification — you can ignore it for personal use.
+
+Testing status is only the right choice if you plan to click through the
+weekly re-auth manually, or if you want to experiment with the flow before
+committing to Production status. You can switch modes at any time; existing
+tokens are not invalidated by the change but new tokens picked up after the
+switch inherit the new lifetime.
 
 ---
 

--- a/docs/deploy/oauth-bootstrap.md
+++ b/docs/deploy/oauth-bootstrap.md
@@ -34,7 +34,31 @@ With your project selected:
 - **Scopes:** skip for now — the app requests scopes at runtime.
 - **Test users:** add your own Google account email. This is the account you'll authorize in step 5.
 
-**Publishing status: leave it as Testing.** Testing mode caps the app at 100 authorized users and skips Google's OAuth verification process entirely — no review queue, no branding review, no wait. Since you're the only user (you are the test user you just added), this is the correct configuration. Do not click "Publish" — that triggers the verification process and offers nothing in return for a personal deployment.
+**Publishing status: leave it as Testing.** Testing mode caps the app at 100
+authorized users and skips Google's OAuth verification process entirely — no
+review queue, no branding review, no wait.
+
+> ⚠️ **Testing-mode refresh tokens expire in 7 days.** For OAuth apps in
+> Testing status that request sensitive scopes (which `youtube` is), Google
+> caps refresh-token lifetime at 7 days regardless of activity. Your
+> `token.json` will start failing with `RefreshError` / 401 roughly a week
+> after each bootstrap. For personal deploy-your-own use this means you
+> need to re-run this bootstrap and re-upload `token.json` once a week.
+>
+> Options if that's untenable:
+> 1. **Publish the app to Production status.** Refresh tokens then last
+>    until revoked (typically ~6 months of inactivity). For unverified
+>    apps requesting sensitive scopes, Google shows users a "This app isn't
+>    verified" warning during consent — you can click through it since you
+>    are the developer. Sensitive-scope verification (removing the warning)
+>    is a Google review process not worth pursuing for personal use.
+> 2. **Automate the weekly re-auth.** Not covered by this project today;
+>    would need a monitoring hook + a scripted re-auth flow.
+>
+> Publishing to Production without verification is the pragmatic default
+> for one-user deploy-your-own. Do that via OAuth consent screen → **Publish
+> app**. The warning during your own consent is a one-time click. Google
+> may email periodically about verification; you can ignore it for personal use.
 
 ---
 
@@ -54,8 +78,8 @@ After creation, click **Download JSON**. Rename the downloaded file to `client_s
 You need the repo on your laptop and `uv` installed ([https://docs.astral.sh/uv/](https://docs.astral.sh/uv/)).
 
 ```bash
-git clone https://github.com/keif/yt-sub-playlist.git
-cd yt-sub-playlist
+git clone https://github.com/keif/playlist-from-subs.git
+cd playlist-from-subs
 uv sync
 ```
 


### PR DESCRIPTION
First half of #17 (bootstrap doc). The `docs/DEPLOY.md` index and README link are still pending — they need all three runbook PRs (#21, #22, #23) merged first to link at.

## Summary

Adds `docs/deploy/oauth-bootstrap.md` — the shared "GCP + OAuth + `token.json`" setup all three deploy runbooks link to. Steps: create GCP project → enable YouTube Data API v3 → configure OAuth consent screen → create Desktop-type OAuth client → download `client_secrets.json` → run local bootstrap → get `token.json`.

## The big decision this PR forces us to make: OAuth publishing status

Codex's first review turned up a **significant gotcha** I did not know about: Google issues **7-day refresh tokens** for OAuth apps in Testing status when they request sensitive scopes (which the `youtube` scope is). The 6-month expiry most personal OAuth apps get only applies to apps in Production status.

For deploy-your-own, that means Testing status is impractical — users would need to re-run this bootstrap and re-upload `token.json` every week. So this doc now **recommends Production status (unverified)** as the primary path:

- **Production, unverified:** click through the one-time "This app isn't verified" warning during your own consent. Refresh tokens then last ~6 months. This is what most personal automations settle on.
- **Testing:** kept as an option for people who just want to experiment before committing. Not the recommended path for cron use.

This is honest and pragmatic, but it does mean the very first step of deploy-your-own asks users to click through an "unverified app" warning against their own Google account. That's the tradeoff for not going through Google's sensitive-scope verification process (which is a real review not worth pursuing for a one-user tool).

## Codex review history

| Pass | Findings | Fixed in |
|---|---|---|
| 1 | P1 7-day Testing-mode expiry not documented; P2 wrong clone URL | `8dbcfab` |
| 2 | P2 my first fix left a Testing-vs-Production contradiction | `420c2f7` |
| 3 | Clean — no findings | merge |

## Cross-PR / downstream

- Once this merges, the broken `docs/deploy/oauth-bootstrap.md` links in PRs #21, #22, #23 resolve.
- **Runbook consistency check needed after merge.** The three runbook PRs mention refresh-token expiry symptoms; they should be re-read against this doc's Production-unverified recommendation. If any runbook still implies "Testing status is fine," patch it.
- The `docs/DEPLOY.md` index and the README link (the second half of #17) are still pending.

## Test plan

- [ ] Walk a fresh Google account through the doc end-to-end, click through the Production-unverified warning, confirm a token issued that way survives longer than a week
- [ ] Sanity-check the runbooks after this + #21 + #22 + #23 land together — no stale "Testing" references