### PR TITLE
fix(cli): --dry-run no longer creates a playlist when PLAYLIST_ID is unset

### DIFF
--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -141,13 +141,11 @@ docker compose run --rm sync --dry-run
 
 Expected: the sync logic runs, no videos are added to the playlist, no errors. If you see `ModuleNotFoundError` or a credentials failure, check that both JSON files landed in `./data/` with correct permissions.
 
-> **--dry-run is not fully no-mutation on first run.** If `PLAYLIST_ID` is
-> not set in `config.json` or `.env`, the CLI creates a new empty playlist
-> on YouTube before entering dry-run mode (that's the "or create" side of
-> `get_or_create_playlist`). Set `PLAYLIST_ID` in your `./data/.env`
-> before the first `--dry-run` if you want strictly no-mutation verification.
-> Follow-up code work will move this side effect behind the `--dry-run`
-> gate.
+> **--dry-run is strictly no-mutation.** With `PLAYLIST_ID` unset, dry-run
+> skips the playlist-create call entirely and logs what would have been
+> created. With `PLAYLIST_ID` set, dry-run verifies the playlist exists
+> (read-only) then reports what would be added. Either way, nothing on
+> your YouTube account changes.
 
 ---
 

--- a/tests/test_dry_run_playlist.py
+++ b/tests/test_dry_run_playlist.py
@@ -1,0 +1,88 @@
+"""
+Regression tests for issue #25: --dry-run must not create a playlist.
+
+Prior behaviour: PlaylistManager.get_or_create_playlist called the underlying
+YouTubeClient unconditionally, and YouTubeClient.get_or_create_playlist
+inserted a new playlist whenever it was passed a None playlist_id. Running
+`--dry-run` with PLAYLIST_ID unset therefore mutated the user's YouTube
+account before the dry-run branch of the sync ever ran.
+
+These tests pin the fixed behaviour:
+
+- dry-run + no playlist_id → no API insert, sentinel returned, warning logged
+- dry-run + explicit playlist_id → read-only verification still happens
+- non-dry-run + no playlist_id → insert path still runs (unchanged)
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from yt_sub_playlist.core.playlist_manager import PlaylistManager
+
+
+class DryRunPlaylistTests(unittest.TestCase):
+    def _make_manager(self):
+        manager = PlaylistManager.__new__(PlaylistManager)
+        manager.client = MagicMock()
+        manager.cache = MagicMock()
+        manager.filter = MagicMock()
+        manager.data_dir = "yt_sub_playlist/data"
+        manager.config = {}
+        return manager
+
+    def test_dry_run_without_playlist_id_never_calls_client(self):
+        manager = self._make_manager()
+
+        result = manager.get_or_create_playlist(
+            playlist_id=None,
+            playlist_name="my playlist",
+            privacy_status="unlisted",
+            dry_run=True,
+        )
+
+        manager.client.get_or_create_playlist.assert_not_called()
+        self.assertEqual(result, PlaylistManager.DRY_RUN_PLAYLIST_ID)
+
+    def test_dry_run_with_playlist_id_still_verifies_existence(self):
+        manager = self._make_manager()
+        manager.client.get_or_create_playlist.return_value = "PLxxx"
+
+        result = manager.get_or_create_playlist(
+            playlist_id="PLxxx",
+            playlist_name="my playlist",
+            privacy_status="unlisted",
+            dry_run=True,
+        )
+
+        manager.client.get_or_create_playlist.assert_called_once_with(
+            playlist_id="PLxxx",
+            playlist_name="my playlist",
+            privacy_status="unlisted",
+        )
+        self.assertEqual(result, "PLxxx")
+
+    def test_non_dry_run_without_playlist_id_still_creates(self):
+        manager = self._make_manager()
+        manager.client.get_or_create_playlist.return_value = "PLnew"
+
+        result = manager.get_or_create_playlist(
+            playlist_id=None,
+            playlist_name=None,
+            privacy_status="unlisted",
+            dry_run=False,
+        )
+
+        manager.client.get_or_create_playlist.assert_called_once()
+        _, kwargs = manager.client.get_or_create_playlist.call_args
+        self.assertIsNone(kwargs["playlist_id"])
+        self.assertEqual(kwargs["playlist_name"], "Auto Playlist from Subscriptions")
+        self.assertEqual(result, "PLnew")
+
+    def test_dry_run_sentinel_is_reserved(self):
+        # If anyone ever changes the sentinel to a plausible-looking real ID,
+        # tests that check "is this a real id" would silently miss the sentinel.
+        self.assertTrue(PlaylistManager.DRY_RUN_PLAYLIST_ID.startswith("("))
+        self.assertIn("dry-run", PlaylistManager.DRY_RUN_PLAYLIST_ID)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yt_sub_playlist/__main__.py
+++ b/yt_sub_playlist/__main__.py
@@ -102,11 +102,15 @@ def main():
             f"oldest entry {cache_stats['oldest_entry_days']} days"
         )
 
-        # Get or create target playlist
+        # Get or create target playlist. In dry-run mode with no PLAYLIST_ID
+        # set, this skips the API insert entirely — see PlaylistManager for
+        # sentinel handling. Closes the "--dry-run still creates a playlist"
+        # side effect (issue #25).
         playlist_id = manager.get_or_create_playlist(
             playlist_id=config["playlist_id"],
             playlist_name=config["playlist_name"],
             privacy_status=config["playlist_visibility"],
+            dry_run=args.dry_run,
         )
 
         # Fetch recent subscription videos and sync to playlist

--- a/yt_sub_playlist/core/playlist_manager.py
+++ b/yt_sub_playlist/core/playlist_manager.py
@@ -143,29 +143,48 @@ class PlaylistManager:
 
         return detailed_results
 
+    DRY_RUN_PLAYLIST_ID = "(dry-run)"
+
     def get_or_create_playlist(
         self,
         playlist_id: str = None,
         playlist_name: str = None,
-        privacy_status: str = "unlisted"
+        privacy_status: str = "unlisted",
+        dry_run: bool = False,
     ) -> str:
         """
         Get existing playlist or create new one.
+
+        In dry-run mode, no playlist is ever created. If ``playlist_id`` is
+        supplied it is still verified read-only against the API (safe under
+        dry-run semantics). If ``playlist_id`` is not supplied, the method
+        logs what would be created and returns a sentinel string so the sync
+        pipeline can proceed to its own dry-run logging.
 
         Args:
             playlist_id: Existing playlist ID (if provided)
             playlist_name: Name for new playlist (if creating)
             privacy_status: Privacy setting for new playlist
+            dry_run: If True, never create a playlist even when playlist_id is None
 
         Returns:
-            Playlist ID
+            Playlist ID (or ``DRY_RUN_PLAYLIST_ID`` sentinel in dry-run + no id)
 
         Raises:
             SystemExit: If playlist operations fail
         """
+        resolved_name = playlist_name or "Auto Playlist from Subscriptions"
+
+        if dry_run and not playlist_id:
+            logger.info(
+                f"DRY RUN: Would create playlist '{resolved_name}' "
+                f"(privacy={privacy_status}). Set PLAYLIST_ID to skip this step."
+            )
+            return self.DRY_RUN_PLAYLIST_ID
+
         resolved_id = self.client.get_or_create_playlist(
             playlist_id=playlist_id,
-            playlist_name=playlist_name or "Auto Playlist from Subscriptions",
+            playlist_name=resolved_name,
             privacy_status=privacy_status
         )
 


### PR DESCRIPTION
Closes #25.

## Summary

`PlaylistManager.get_or_create_playlist()` now accepts `dry_run`. In dry-run mode with no `PLAYLIST_ID`, it logs what would be created and returns a sentinel string (`PlaylistManager.DRY_RUN_PLAYLIST_ID = "(dry-run)"`) instead of calling `YouTubeClient.get_or_create_playlist()` (which would `playlists.insert` a new empty playlist). `main.py` passes `args.dry_run` through.

## Why

Discovered during codex review of the raw Docker runbook (#16 / PR #23). Original behavior mutated the user's YouTube account before the dry-run branch of the sync ran — surprise "Auto Playlist from Subscriptions" playlists for anyone who tried `--dry-run` before setting `PLAYLIST_ID`.

## Behavior matrix

| `dry_run` | `PLAYLIST_ID` | Result |
|---|---|---|
| False | any | Unchanged — insert or verify per prior behavior |
| True | set | Read-only verify via `playlists.list` (safe) |
| True | unset | **NEW:** log what would be created, return sentinel, no API mutation |

## Tests

Adds `tests/test_dry_run_playlist.py` — four regression tests (stdlib `unittest`, no new deps):
1. `test_dry_run_without_playlist_id_never_calls_client` — pins the bug fix
2. `test_dry_run_with_playlist_id_still_verifies_existence` — read-only verify path still works
3. `test_non_dry_run_without_playlist_id_still_creates` — no regression in the happy path
4. `test_dry_run_sentinel_is_reserved` — sentinel string invariant

Run: `uv run python -m unittest tests.test_dry_run_playlist -v`

## Downstream check

Codex confirmed: the sentinel `"(dry-run)"` only travels into `add_videos_to_playlist(..., dry_run=True)`, which returns before any playlist API call. No other write path exists in the sync flow, so the sentinel is safe end-to-end.

## Also updates

`docs/deploy/docker.md` — the callout warning that `--dry-run` leaves artifacts is no longer accurate. Replaced with an affirmative "strictly no-mutation" note.