### PR TITLE
feat(config): honor YT_SUB_PLAYLIST_DATA_DIR env var for state and cache

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -44,4 +44,10 @@ write_secret TOKEN_B64 token.json
 # files regardless of how the container was invoked.
 cd "$DATA_DIR"
 
+# Point the app's runtime state (playlist_cache/, processed_videos.json,
+# api_call_log.json) at /data directly rather than the historical
+# yt_sub_playlist/data/ subdirectory that resolves under cwd for local dev.
+# See yt_sub_playlist/core/playlist_manager.py::resolve_data_dir and issue #26.
+export YT_SUB_PLAYLIST_DATA_DIR="$DATA_DIR"
+
 exec "$@"

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -36,19 +36,16 @@ All credentials and runtime state live in `./data/`. The compose file mounts it 
     ├── token.json                    (credentials, you provide; refreshed in place)
     ├── config.json                   (optional)
     ├── .env                          (optional)
-    └── yt_sub_playlist/data/         (runtime state — see note below)
-        ├── processed_videos.json
-        ├── playlist_cache/
-        └── api_call_log.json
+    ├── processed_videos.json          (runtime state)
+    ├── playlist_cache/                (runtime state)
+    └── api_call_log.json              (runtime state)
 ```
 
-> **Note about the buried runtime state.** The CLI's default `data_dir` is
-> `"yt_sub_playlist/data"` (a relative path baked in for local-dev use). The
-> container's entrypoint cd's to `/data`, so runtime state actually lands
-> under `./data/yt_sub_playlist/data/` on the host, not directly next to
-> `token.json`. Look there when backing up or inspecting the cache. A
-> follow-up issue will unify this via a `YT_SUB_PLAYLIST_DATA_DIR` env var
-> so the container can write state directly under `/data`.
+The container's entrypoint sets `YT_SUB_PLAYLIST_DATA_DIR=/data` so runtime
+state files sit at the root of the bind-mounted directory alongside your
+credentials. Local development that runs `python -m yt_sub_playlist` from a
+repo checkout still writes into `yt_sub_playlist/data/` by default (backwards
+compatible), so nothing changes for laptop use.
 
 ### Drop credentials into ./data/
 
@@ -253,17 +250,15 @@ sudo ls -la ./data/token.json
 
 The dashboard is **out of scope for v1** on raw Docker. It is intentionally
 commented out of `docker-compose.yml`. The dashboard backend's data-source
-path is currently hard-coded to a local checkout — the same buried
-`yt_sub_playlist/data/` mentioned in the Directory layout note — and does
-not read a data-dir override env var, so simply mounting the server's
-`./data/` locally is not enough to point the dashboard at it.
+path is currently hard-coded, so it does not yet honour the same
+`YT_SUB_PLAYLIST_DATA_DIR` env var the CLI uses (the CLI got that in
+issue #26; extending it to the dashboard is a future change).
 
 For now, treat "look at the server's state" as an admin-shell task:
-`ssh user@your-server 'ls -la /srv/yt-sub-playlist/data/yt_sub_playlist/data/'`.
+`ssh user@your-server 'ls -la /srv/yt-sub-playlist/data/'`.
 
-A future spec will cover dashboard deploy (with a proper auth layer) and,
-alongside it, a data-dir env var that lets the dashboard point at a mounted
-or remote directory.
+A future spec will cover dashboard deploy with a proper auth layer and
+teach the dashboard to point at a mounted or remote directory.
 
 ---
 

--- a/tests/test_data_dir.py
+++ b/tests/test_data_dir.py
@@ -1,0 +1,54 @@
+"""
+Regression tests for issue #26: honor YT_SUB_PLAYLIST_DATA_DIR env var.
+
+Prior behavior: PlaylistManager.__init__ hard-coded data_dir to
+"yt_sub_playlist/data" as a relative path. When the container entrypoint
+cd'd into /data, runtime state files (playlist_cache/, processed_videos.json,
+api_call_log.json) ended up buried at /data/yt_sub_playlist/data/ instead
+of directly under /data.
+
+Fix: PlaylistManager honors a YT_SUB_PLAYLIST_DATA_DIR env var with
+explicit-arg > env var > default precedence. Local dev keeps the historical
+default when the env var is unset (backwards compatible).
+"""
+import os
+import unittest
+from unittest.mock import patch
+
+from yt_sub_playlist.core.playlist_manager import (
+    DEFAULT_DATA_DIR,
+    resolve_data_dir,
+)
+
+
+class ResolveDataDirTests(unittest.TestCase):
+    def test_explicit_arg_wins_over_env(self):
+        with patch.dict(os.environ, {"YT_SUB_PLAYLIST_DATA_DIR": "/from-env"}):
+            self.assertEqual(resolve_data_dir("/explicit"), "/explicit")
+
+    def test_env_var_wins_over_default(self):
+        with patch.dict(os.environ, {"YT_SUB_PLAYLIST_DATA_DIR": "/data"}):
+            self.assertEqual(resolve_data_dir(), "/data")
+
+    def test_default_when_neither_set(self):
+        env_without = {k: v for k, v in os.environ.items() if k != "YT_SUB_PLAYLIST_DATA_DIR"}
+        with patch.dict(os.environ, env_without, clear=True):
+            self.assertEqual(resolve_data_dir(), DEFAULT_DATA_DIR)
+
+    def test_empty_env_var_falls_back_to_default(self):
+        # An exported-but-empty env var (`export YT_SUB_PLAYLIST_DATA_DIR=`)
+        # should behave the same as unset — accidentally exporting empty
+        # values is a common shell mistake and shouldn't crater state
+        # into a relative "" path.
+        with patch.dict(os.environ, {"YT_SUB_PLAYLIST_DATA_DIR": ""}):
+            self.assertEqual(resolve_data_dir(), DEFAULT_DATA_DIR)
+
+    def test_default_matches_historical_relative_path(self):
+        # The default is the historical relative path so `python -m
+        # yt_sub_playlist` from a fresh repo checkout keeps writing state
+        # to yt_sub_playlist/data/ — unchanged behaviour for local dev.
+        self.assertEqual(DEFAULT_DATA_DIR, "yt_sub_playlist/data")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yt_sub_playlist/__main__.py
+++ b/yt_sub_playlist/__main__.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 
 from .config.env_loader import load_config, setup_logging
-from .core.playlist_manager import PlaylistManager
+from .core.playlist_manager import PlaylistManager, resolve_data_dir
 from .core.video_filtering import get_published_after_timestamp, parse_channel_whitelist
 from .core.youtube_client import dump_api_call_log
 
@@ -65,7 +65,7 @@ Examples:
 def _dump_api_call_log():
     """Dump API call log for quota analysis."""
     try:
-        log_path = Path("yt_sub_playlist/data/api_call_log.json")
+        log_path = Path(resolve_data_dir()) / "api_call_log.json"
         dump_api_call_log(log_path)
     except Exception as e:
         logger.debug(f"Failed to dump API call log: {e}")

--- a/yt_sub_playlist/core/playlist_manager.py
+++ b/yt_sub_playlist/core/playlist_manager.py
@@ -21,6 +21,28 @@ from ..config.env_loader import VideoCache
 logger = logging.getLogger(__name__)
 
 
+# Local-dev default; the container entrypoint sets YT_SUB_PLAYLIST_DATA_DIR=/data
+# so state files land at the root of the mounted volume instead of a
+# nested yt_sub_playlist/data/ subdirectory. Kept as a module-level constant
+# so tests and downstream callers can reference it explicitly.
+DEFAULT_DATA_DIR = "yt_sub_playlist/data"
+
+
+def resolve_data_dir(explicit: str = None) -> str:
+    """
+    Resolve the data directory using the precedence:
+    explicit arg > YT_SUB_PLAYLIST_DATA_DIR env var > DEFAULT_DATA_DIR.
+
+    The env-var override exists so the container's entrypoint can point
+    the app at /data (see docker/entrypoint.sh and issue #26). Local
+    development that runs `python -m yt_sub_playlist` from the repo root
+    keeps the historical behaviour when the env var is not set.
+    """
+    if explicit:
+        return explicit
+    return os.getenv("YT_SUB_PLAYLIST_DATA_DIR") or DEFAULT_DATA_DIR
+
+
 class PlaylistManager:
     """
     High-level manager for YouTube playlist automation.
@@ -32,18 +54,22 @@ class PlaylistManager:
     4. Generate reports and analytics
     """
 
-    def __init__(self, config: Dict[str, Any], data_dir: str = "yt_sub_playlist/data"):
+    def __init__(self, config: Dict[str, Any], data_dir: str = None):
         """
         Initialize playlist manager.
 
         Args:
             config: Application configuration dictionary
-            data_dir: Directory for data storage and caching
+            data_dir: Directory for data storage and caching. When None
+                (the default), resolves via YT_SUB_PLAYLIST_DATA_DIR env
+                var or falls back to ``DEFAULT_DATA_DIR`` — see
+                ``resolve_data_dir``.
         """
+        resolved_data_dir = resolve_data_dir(data_dir)
         self.config = config
-        self.data_dir = data_dir
-        self.client = YouTubeClient(data_dir)
-        self.cache = VideoCache(data_dir=data_dir)
+        self.data_dir = resolved_data_dir
+        self.client = YouTubeClient(resolved_data_dir)
+        self.cache = VideoCache(data_dir=resolved_data_dir)
         self.filter = VideoFilter(config, self.cache)
 
     def sync_subscription_videos_to_playlist(

--- a/yt_sub_playlist/scripts/quota_simulator.py
+++ b/yt_sub_playlist/scripts/quota_simulator.py
@@ -18,7 +18,11 @@ def load_api_call_log() -> dict:
     Returns:
         Dictionary of API call counts, or fallback hardcoded values if log missing.
     """
-    log_path = Path("yt_sub_playlist/data/api_call_log.json")
+    # Match the same YT_SUB_PLAYLIST_DATA_DIR resolution the CLI uses.
+    # Inlined rather than imported because this script uses sys.path
+    # gymnastics that don't play well with package imports.
+    data_dir = os.getenv("YT_SUB_PLAYLIST_DATA_DIR") or "yt_sub_playlist/data"
+    log_path = Path(data_dir) / "api_call_log.json"
     
     try:
         if log_path.exists():


### PR DESCRIPTION
Closes #26.

## Summary

The CLI now honors a `YT_SUB_PLAYLIST_DATA_DIR` environment variable. When set, `PlaylistManager`, `_dump_api_call_log`, and `scripts/quota_simulator.py` route all runtime state (`processed_videos.json`, `playlist_cache/`, `api_call_log.json`) into that directory. Precedence is explicit-arg > env var > `DEFAULT_DATA_DIR` (`"yt_sub_playlist/data"`).

The container's entrypoint now exports `YT_SUB_PLAYLIST_DATA_DIR=/data`, so a `docker run` of the image writes state alongside `client_secrets.json` and `token.json` at `/data/*` instead of the previous buried `/data/yt_sub_playlist/data/*`.

Local dev is unchanged: `python -m yt_sub_playlist` from a fresh repo checkout with no env var set keeps writing into `yt_sub_playlist/data/` (backwards compatible).

## Why

Surfaced during codex review of the raw Docker runbook (#16 / PR #23). The runbook had to include a whole "buried runtime state" callout because state files landed one directory deeper than the credentials the user had explicitly placed in `./data/`. The runbook now has a straightforward file-tree.

## Codex review history

| Pass | Findings | Fixed in |
|---|---|---|
| 1 | P2 `_dump_api_call_log` and `quota_simulator.py` had their own hardcoded paths | `65b2280` |
| 2 | Clean | merge |

## Tests

`tests/test_data_dir.py` — five stdlib `unittest` cases:
- Explicit arg wins over env var
- Env var wins over default
- Default when neither set
- Empty env var (`export YT_SUB_PLAYLIST_DATA_DIR=`) falls back to default (protects against a common shell mistake)
- Default string matches the historical `yt_sub_playlist/data` value

Total suite is now 9 tests (5 new + 4 from #25). `uv run python -m unittest discover -s tests` passes.

## Container smoke-test

Rebuilt the image and confirmed:
```
$ docker run --rm --entrypoint /usr/local/bin/entrypoint.sh yt-sub-playlist:dev sh -c 'echo "YT_SUB_PLAYLIST_DATA_DIR=$YT_SUB_PLAYLIST_DATA_DIR"; echo "cwd=$(pwd)"'
YT_SUB_PLAYLIST_DATA_DIR=/data
cwd=/data
```

## Downstream

- Docker runbook's file-tree diagram updated; "buried runtime state" callout deleted.
- Dashboard backend still uses its own hardcoded path — deliberately out of scope. A future spec that covers dashboard deploy will teach it to honor the same env var.